### PR TITLE
Add support for remote WebDriver endpoints without /wd/hub in path.

### DIFF
--- a/go/browser.go
+++ b/go/browser.go
@@ -32,6 +32,7 @@ package browser
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/tebeka/selenium/selenium"
 )
@@ -43,12 +44,10 @@ const (
 
 // NewSession provisions and returns a new WebDriver session.
 func NewSession(capabilities selenium.Capabilities) (selenium.WebDriver, error) {
-	hostport, ok := os.LookupEnv(webdriverServerEnvVar)
+	address, ok := os.LookupEnv(webdriverServerEnvVar)
 	if !ok {
 		return nil, fmt.Errorf("environment variable %q is not defined, are you using web_test", webdriverServerEnvVar)
 	}
 
-	address := fmt.Sprintf("http://%s/wd/hub", hostport)
-
-	return selenium.NewRemote(capabilities, address)
+	return selenium.NewRemote(capabilities, strings.TrimSuffix(address, "/"))
 }

--- a/go/launcher/environments/chrome.go
+++ b/go/launcher/environments/chrome.go
@@ -25,7 +25,6 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/launcher/cmdhelper"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/environments/environment"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/services/chromedriver"
-	"github.com/bazelbuild/rules_webtesting/go/launcher/services/service"
 	"github.com/bazelbuild/rules_webtesting/go/metadata/metadata"
 )
 
@@ -37,7 +36,7 @@ const (
 
 type chrome struct {
 	*environment.Base
-	chromedriver *service.Server
+	chromedriver *chromedriver.ChromeDriver
 }
 
 // NewEnv creates a new environment for launching a chrome browser locally using
@@ -73,7 +72,7 @@ func (n *chrome) TearDown(ctx context.Context) error {
 }
 
 func (n *chrome) WDAddress(context.Context) string {
-	return n.chromedriver.Address
+	return n.chromedriver.Address()
 }
 
 func (n *chrome) Healthy(ctx context.Context) error {

--- a/go/launcher/environments/native.go
+++ b/go/launcher/environments/native.go
@@ -25,7 +25,6 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/launcher/cmdhelper"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/environments/environment"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/services/selenium"
-	"github.com/bazelbuild/rules_webtesting/go/launcher/services/service"
 	"github.com/bazelbuild/rules_webtesting/go/metadata/metadata"
 )
 
@@ -37,7 +36,7 @@ const (
 
 type native struct {
 	*environment.Base
-	selenium *service.Server
+	selenium *selenium.Selenium
 }
 
 // NewEnv creates a new environment for launching a browser locally using
@@ -73,7 +72,7 @@ func (n *native) TearDown(ctx context.Context) error {
 }
 
 func (n *native) WDAddress(context.Context) string {
-	return n.selenium.Address
+	return n.selenium.Address()
 }
 
 func (n *native) Healthy(ctx context.Context) error {

--- a/go/launcher/main.go
+++ b/go/launcher/main.go
@@ -111,7 +111,7 @@ func run() int {
 	testCmd := exec.Command(testExe, flag.Args()...)
 	testCmd.Env = cmdhelper.BulkUpdateEnv(os.Environ(), map[string]string{
 		"WEB_TEST_BROWSER_METADATA": *metadataFileFlag,
-		"REMOTE_WEBDRIVER_SERVER":   p.Address,
+		"REMOTE_WEBDRIVER_SERVER":   fmt.Sprintf("http://%s/wd/hub/", p.Address),
 		"TEST_TMPDIR":               tmpDir,
 		"WEB_TEST_TMPDIR":           webTestTmpDir,
 		"WEB_TEST_TARGET":           *test,

--- a/go/launcher/proxy/driver_hub.go
+++ b/go/launcher/proxy/driver_hub.go
@@ -129,7 +129,7 @@ func (h *hub) createSession(ctx context.Context, w http.ResponseWriter, r *http.
 
 	log.Printf("Caps: %+v", desired)
 	// TODO(fisherii) parameterize attempts based on browser metadata
-	driver, err := webdriver.CreateSession(ctx, "http://"+h.env.WDAddress(ctx)+"/wd/hub/", 3, desired)
+	driver, err := webdriver.CreateSession(ctx, h.env.WDAddress(ctx), 3, desired)
 	if err != nil {
 		if err2 := h.env.StopSession(ctx, id); err2 != nil {
 			log.Printf("error stopping session after failing to launch webdriver: %v", err2)

--- a/go/launcher/services/chromedriver.go
+++ b/go/launcher/services/chromedriver.go
@@ -18,6 +18,7 @@
 package chromedriver
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/bazelbuild/rules_webtesting/go/launcher/errors"
@@ -25,20 +26,31 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/metadata/metadata"
 )
 
+type ChromeDriver struct {
+	*service.Server
+}
+
 // New creates a new service.Server instance that manages chromedriver.
-func New(m *metadata.Metadata, xvfb bool) (*service.Server, error) {
-	chromedriverPath, err := m.GetFilePath("CHROMEDRIVER")
+func New(m *metadata.Metadata, xvfb bool) (*ChromeDriver, error) {
+	chromeDriverPath, err := m.GetFilePath("CHROMEDRIVER")
 	if err != nil {
 		return nil, errors.New("ChromeDriver", err)
 	}
 
-	return service.NewServer(
+	server, err := service.NewServer(
 		"ChromeDriver",
-		chromedriverPath,
-		"http://%s/wd/hub/status",
+		chromeDriverPath,
+		"http://%s/status",
 		xvfb,
 		60*time.Second,
 		nil,
-		"--port={port}",
-		"--url-base=wd/hub")
+		"--port={port}")
+	if err != nil {
+		return nil, err
+	}
+	return &ChromeDriver{server}, nil
+}
+
+func (c *ChromeDriver) Address() string {
+	return fmt.Sprintf("http://%s/", c.Server.Address())
 }

--- a/go/launcher/services/server.go
+++ b/go/launcher/services/server.go
@@ -34,7 +34,7 @@ import (
 // Server is a service that starts an external server.
 type Server struct {
 	*Cmd
-	Address       string
+	address       string
 	port          int
 	healthPattern string
 	timeout       time.Duration
@@ -58,7 +58,7 @@ func NewServer(name, exe, healthPattern string, xvfb bool, timeout time.Duration
 	}
 	return &Server{
 		Cmd:           cmd,
-		Address:       net.JoinHostPort("localhost", strconv.Itoa(port)),
+		address:       net.JoinHostPort("localhost", strconv.Itoa(port)),
 		port:          port,
 		healthPattern: healthPattern,
 		timeout:       timeout,
@@ -94,7 +94,7 @@ func (s *Server) Healthy(ctx context.Context) error {
 		return err
 	}
 
-	url := fmt.Sprintf(s.healthPattern, s.Address)
+	url := fmt.Sprintf(s.healthPattern, s.address)
 	resp, err := httphelper.Get(ctx, url)
 	if err != nil {
 		return errors.New(s.Name(), fmt.Errorf("error getting %s: %v", url, err))
@@ -109,4 +109,8 @@ func (s *Server) Healthy(ctx context.Context) error {
 // Port returns the port this server is running on as a string.
 func (s *Server) Port() string {
 	return fmt.Sprintf("%d", s.port)
+}
+
+func (s *Server) Address() string {
+	return s.address
 }

--- a/go/util/http_helper.go
+++ b/go/util/http_helper.go
@@ -18,18 +18,26 @@ package httphelper
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 var client = &http.Client{}
 
 // Forward forwards r to host and writes the response from host to w.
 func Forward(ctx context.Context, host string, w http.ResponseWriter, r *http.Request) error {
-	url := "http://" + host + r.URL.Path
+	log.Printf("MRF: %+v", r)
+	url, err := constructURL(host, r.URL.Path, "/wd/hub/")
+	if err != nil {
+		return err
+	}
 
 	// Construct request based on Method, URL Path, and Body from r
-	request, err := http.NewRequest(r.Method, url, r.Body)
+	request, err := http.NewRequest(r.Method, url.String(), r.Body)
 	if err != nil {
 		return err
 	}
@@ -69,4 +77,22 @@ func Get(ctx context.Context, url string) (*http.Response, error) {
 	}
 	request = request.WithContext(ctx)
 	return client.Do(request)
+}
+
+func constructURL(base, path, prefix string) (*url.URL, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasPrefix(path, prefix) {
+		return nil, fmt.Errorf("%q does not have expected prefix %q", path, prefix)
+	}
+
+	ref, err := url.Parse(strings.TrimPrefix(path, prefix))
+	if err != nil {
+		return nil, err
+	}
+
+	return u.ResolveReference(ref), err
 }

--- a/go/util/http_helper.go
+++ b/go/util/http_helper.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,7 +29,6 @@ var client = &http.Client{}
 
 // Forward forwards r to host and writes the response from host to w.
 func Forward(ctx context.Context, host string, w http.ResponseWriter, r *http.Request) error {
-	log.Printf("MRF: %+v", r)
 	url, err := constructURL(host, r.URL.Path, "/wd/hub/")
 	if err != nil {
 		return err

--- a/java/com/google/testing/web/Browser.java
+++ b/java/com/google/testing/web/Browser.java
@@ -45,14 +45,18 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class Browser {
 
-  @Nullable private final String address;
+  @Nullable private final URL url;
 
   public Browser() {
     this(System.getenv("REMOTE_WEBDRIVER_SERVER"));
   }
 
   private Browser(String address) {
-    this.address = address;
+    try {
+      this.url = new URL(address);
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /** Provisions and returns a new default {@link WebDriver} session. */
@@ -67,16 +71,8 @@ public class Browser {
    */
   public WebDriver newSession(Capabilities capabilities) {
     DesiredCapabilities desired = new DesiredCapabilities(capabilities);
-    WebDriver driver = new Augmenter().augment(new RemoteWebDriver(constructUrl(address), desired));
+    WebDriver driver = new Augmenter().augment(new RemoteWebDriver(url, desired));
 
     return driver;
-  }
-
-  private static URL constructUrl(String hostAndPort) {
-    try {
-      return new URL(String.format("http://%s/wd/hub", hostAndPort));
-    } catch (MalformedURLException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/testing/web/browser.py
+++ b/testing/web/browser.py
@@ -33,7 +33,7 @@ class Browser(object):
   """Browser provisioning and information API."""
 
   def __init__(self):
-    self._address = os.environ["REMOTE_WEBDRIVER_SERVER"]
+    self._address = os.environ['REMOTE_WEBDRIVER_SERVER']
 
   def new_session(self, capabilities=None):
     """Provisions a new WebDriver session.
@@ -55,4 +55,4 @@ class Browser(object):
     # timeout is not used.
     remote_connection.RemoteConnection.set_timeout(450)
     return webdriver.WebDriver(
-        "http://%s/wd/hub" % self._address, desired_capabilities=desired)
+        self._address.rstrip('/'), desired_capabilities=desired)


### PR DESCRIPTION
*  Change services that launcher WebDriver endpoints to return a
   address string with the full path.
*  Change WebDriver hub to correctly construct urls to forward commands.
*  Change WTL to export full path to WebDriver server in environment.
*  Change client libraries to expect full path to WebDriver server in
   environment.