### PR TITLE
sandbox_tmpfs_path is not in the released Bazel

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,1 +1,2 @@
-test --sandbox_tmpfs_path=/run/shm
+# sandbox_tmpfs_path is not in the released Bazel.
+# test --sandbox_tmpfs_path=/run/shm


### PR DESCRIPTION
We need to comment this out until a release containing sandbox_tmpfs_path. This is causing failures on CI.