### PR TITLE
Cleanup go comments and rename launcher.

### DIFF
--- a/go/browserinfo_test.go
+++ b/go/browserinfo_test.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package webtest
 
 import "testing"

--- a/go/launcher/BUILD
+++ b/go/launcher/BUILD
@@ -21,8 +21,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 licenses(["notice"])  # Apache 2.0
 
 go_binary(
-    name = "main",
-    srcs = ["main.go"],
+    name = "launcher",
+    srcs = ["launcher.go"],
     visibility = ["//visibility:public"],
     deps = [
         ":cmdhelper",

--- a/go/launcher/cmd_helper.go
+++ b/go/launcher/cmd_helper.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package cmdhelper provides functions to make working os/exec Command easier.
 package cmdhelper
 

--- a/go/launcher/environments/chrome.go
+++ b/go/launcher/environments/chrome.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package native provides an Env for launching a chrome browser locally using
 // ChromeDriver.
 package chrome

--- a/go/launcher/environments/environment.go
+++ b/go/launcher/environments/environment.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package environment provides an interface for defining how browser environments
 // are managed.
 package environment

--- a/go/launcher/environments/external.go
+++ b/go/launcher/environments/external.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package external
 
 import (

--- a/go/launcher/environments/firefox.go
+++ b/go/launcher/environments/firefox.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package native provides an Env for launching a chrome browser locally using
 // ChromeDriver.
 package firefox

--- a/go/launcher/environments/native.go
+++ b/go/launcher/environments/native.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package native provides an Env for launching a browser locally using
 // GoogleSeleniumServer.
 package native

--- a/go/launcher/errors.go
+++ b/go/launcher/errors.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package errors provides an Error interface that includes the component name with the underlying error.
 package errors
 

--- a/go/launcher/errors_test.go
+++ b/go/launcher/errors_test.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package errors
 
 import (

--- a/go/launcher/health_reporter.go
+++ b/go/launcher/health_reporter.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package healthreporter provides polling wait functions.
 package healthreporter
 

--- a/go/launcher/health_reporter_test.go
+++ b/go/launcher/health_reporter_test.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package healthreporter
 
 import (

--- a/go/launcher/launcher.go
+++ b/go/launcher/launcher.go
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
+// Binary launcher is used to manage the envrionment for web tests and start the underlying test.
 package main
 
 import (

--- a/go/launcher/proxy/driver_hub.go
+++ b/go/launcher/proxy/driver_hub.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package driverhub provides a handler for proxying connections to a Selenium server.
 package driverhub
 

--- a/go/launcher/proxy/driver_responses.go
+++ b/go/launcher/proxy/driver_responses.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package driverhub
 
 import (

--- a/go/launcher/proxy/driver_session.go
+++ b/go/launcher/proxy/driver_session.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package driverhub
 
 import (

--- a/go/launcher/proxy/proxy.go
+++ b/go/launcher/proxy/proxy.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package proxy provides a WebDriver protocol that forwards requests
 // to a WebDriver server provided by an environment.Env.
 package proxy

--- a/go/launcher/proxy/webdriver.go
+++ b/go/launcher/proxy/webdriver.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package webdriver provides a simple and incomplete WebDriver client for use by web test launcher.
 package webdriver
 

--- a/go/launcher/services/chromedriver.go
+++ b/go/launcher/services/chromedriver.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package chromedriver provides a service.Server for managing an instance of chromedriver.
 package chromedriver
 

--- a/go/launcher/services/cmd.go
+++ b/go/launcher/services/cmd.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package service
 
 import (

--- a/go/launcher/services/geckodriver.go
+++ b/go/launcher/services/geckodriver.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package chromedriver provides a service.Server for managing an instance of GeckoDriver.
 package geckodriver
 

--- a/go/launcher/services/selenium.go
+++ b/go/launcher/services/selenium.go
@@ -1,3 +1,18 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package selenium provides a service.Server for managing an instance of Selenium Standalone server.
 package selenium
 
 import (

--- a/go/launcher/services/server.go
+++ b/go/launcher/services/server.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package service
 
 import (

--- a/go/launcher/services/service.go
+++ b/go/launcher/services/service.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package service provides the Service interface for managing the life-cycle
 // of a single binary.
 package service

--- a/go/metadata/capabilities.go
+++ b/go/metadata/capabilities.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package capabilities performs operations on maps representing WebDriver capabilities.
 package capabilities
 

--- a/go/metadata/capabilities_test.go
+++ b/go/metadata/capabilities_test.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package capabilities
 
 import "testing"

--- a/go/metadata/extension_test.go
+++ b/go/metadata/extension_test.go
@@ -11,8 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
+
 package metadata
 
 import (

--- a/go/metadata/merger.go
+++ b/go/metadata/merger.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Binary merger takes multiple metadata files and merges them to produce a single
 // metadata file.
 package main

--- a/go/metadata/metadata.go
+++ b/go/metadata/metadata.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 // Package metadata provides a struct for storing browser metadata.
 package metadata
 

--- a/go/metadata/metadata_test.go
+++ b/go/metadata/metadata_test.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package metadata
 
 import (

--- a/go/metadata/testdata/extension.json
+++ b/go/metadata/testdata/extension.json
@@ -5,7 +5,7 @@
   "testLabel": "//go/launcher:tests",
   "namedExecutables": {},
   "extension": {
-	  "ExtensionField1": "hello",
-	  "ExtensionField2": 1024
+    "ExtensionField1": "hello",
+    "ExtensionField2": 1024
   }
 }

--- a/go/metadata/web_test_files.go
+++ b/go/metadata/web_test_files.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package metadata
 
 import (

--- a/go/util/bazel.go
+++ b/go/util/bazel.go
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
+// Package bazel provides utilities for interacting with the surrounding Bazel environment.
 package bazel
 
 import (

--- a/go/util/http_helper.go
+++ b/go/util/http_helper.go
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
+// Package httphelper provides simple wrappers for working with HTTP.
 package httphelper
 
 import (
@@ -68,6 +67,7 @@ func Forward(ctx context.Context, host string, w http.ResponseWriter, r *http.Re
 	return nil
 }
 
+// Get returns the contents located at url.
 func Get(ctx context.Context, url string) (*http.Response, error) {
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/go/util/port_picker.go
+++ b/go/util/port_picker.go
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
+// Package portpicker provides methods for picking unused TCP ports.
 package portpicker
 
 import (
@@ -21,6 +20,7 @@ import (
 	"strconv"
 )
 
+// PickUnusedPort picks an unused TCP port.
 func PickUnusedPort() (int, error) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {

--- a/go/webtest.go
+++ b/go/webtest.go
@@ -11,8 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
+
 // Package webtest provides WebDriver provisioning and information APIs.
 //
 // Provision a browser:
@@ -67,7 +66,7 @@ func newInfo(mf string) (*BrowserInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	m, err := metadata.FromFile(f)
+	m, err := metadata.FromFile(f, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/webtest_test.go
+++ b/go/webtest_test.go
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
+
 package webtest
 
 import (

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -184,7 +184,7 @@ def web_test(browser,
     **kwargs: see web_test in //web/internal:web_test.bzl
   """
   config = config or str(Label("//web:default_config"))
-  launcher = launcher or str(Label("//go/launcher:main"))
+  launcher = launcher or str(Label("//go/launcher"))
   data = lists.clone(data)
   lists.ensure_contains_all(data, [browser, config, launcher, test])
   size = size or "large"


### PR DESCRIPTION
-  Ensure every go package has a package comment.
-  Ensure every go file has copyright header.
-  Detach copyright headers from package comment declaration.
-  Rename //go/launcher:main to //go/launcher.