### PR TITLE
Remove logic that attempts to create /dev/shm.

### DIFF
--- a/web/internal/web_test.sh.template
+++ b/web/internal/web_test.sh.template
@@ -34,10 +34,6 @@ if [[ -z "$TEST_TEMPDIR" ]]; then
   export TEST_TEMPDIR=$(mktemp -d test_tempdir.XXXXXX)
 fi
 
-if [ ! -e "/dev/shm" ]; then
-  mkdir /dev/shm
-fi
-
 %TEMPLATED_env_vars%
 
 printenv


### PR DESCRIPTION
It never worked, and should not be needed with newer versions of Bazel.