### PR TITLE
Add trimPrefix parameter to httphelper.Forward.

### DIFF
--- a/go/launcher/proxy/driver_hub.go
+++ b/go/launcher/proxy/driver_hub.go
@@ -168,7 +168,7 @@ func (h *hub) defaultForward(ctx context.Context, w http.ResponseWriter, r *http
 		return
 	}
 
-	if err := httphelper.Forward(ctx, h.env.WDAddress(ctx), w, r); err != nil {
+	if err := httphelper.Forward(ctx, h.env.WDAddress(ctx), "/wd/hub/", w, r); err != nil {
 		unknownError(w, err)
 	}
 }

--- a/go/util/http_helper.go
+++ b/go/util/http_helper.go
@@ -27,8 +27,8 @@ import (
 var client = &http.Client{}
 
 // Forward forwards r to host and writes the response from host to w.
-func Forward(ctx context.Context, host string, w http.ResponseWriter, r *http.Request) error {
-	url, err := constructURL(host, r.URL.Path, "/wd/hub/")
+func Forward(ctx context.Context, host, trimPrefix string, w http.ResponseWriter, r *http.Request) error {
+	url, err := constructURL(host, r.URL.Path, trimPrefix)
 	if err != nil {
 		return err
 	}
@@ -78,6 +78,9 @@ func Get(ctx context.Context, url string) (*http.Response, error) {
 }
 
 func constructURL(base, path, prefix string) (*url.URL, error) {
+	if !strings.HasPrefix(path, prefix) {
+		prefix = "/" + prefix
+	}
 	u, err := url.Parse(base)
 	if err != nil {
 		return nil, err

--- a/go/util/http_helper.go
+++ b/go/util/http_helper.go
@@ -78,12 +78,13 @@ func Get(ctx context.Context, url string) (*http.Response, error) {
 }
 
 func constructURL(base, path, prefix string) (*url.URL, error) {
-	if !strings.HasPrefix(path, prefix) {
-		prefix = "/" + prefix
-	}
 	u, err := url.Parse(base)
 	if err != nil {
 		return nil, err
+	}
+
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
 	}
 
 	if !strings.HasPrefix(path, prefix) {


### PR DESCRIPTION
trimPrefix determines a prefix of the original path that should be
removed.