### PR TITLE
Make browsers in tests consistent.

### DIFF
--- a/go/BUILD
+++ b/go/BUILD
@@ -56,35 +56,11 @@ go_test(
 
 web_test_suite(
     name = "webtest_test",
-    browser_overrides = {
-        "//browsers:chrome-external": {
-            "tags": [
-                "manual",
-                "noci",
-                "requires-network",
-            ],
-        },
-        "//browsers:firefox-external": {
-            "tags": [
-                "manual",
-                "noci",
-                "requires-network",
-            ],
-        },
-        "//browsers:chromium-native": {
-            "local": True,
-        },
-        "//browsers:firefox-native": {
-            "local": True,
-        },
-    },
     browsers = [
-        "//browsers:chrome-external",
         "//browsers:chromium-native",
-        "//browsers:firefox-external",
         "//browsers:firefox-native",
         "//browsers:phantomjs",
     ],
-    tags = ["noci"],
+    local = True,
     test = ":webtest_test_wrapped",
 )

--- a/go/BUILD
+++ b/go/BUILD
@@ -62,5 +62,6 @@ web_test_suite(
         "//browsers:phantomjs",
     ],
     local = True,
+    tags = ["noci"],
     test = ":webtest_test_wrapped",
 )

--- a/javatests/com/google/testing/web/BUILD
+++ b/javatests/com/google/testing/web/BUILD
@@ -37,35 +37,11 @@ java_test(
 
 web_test_suite(
     name = "WebTestTest",
-    browser_overrides = {
-        "//browsers:chrome-external": {
-            "tags": [
-                "manual",
-                "noci",
-                "requires-network",
-            ],
-        },
-        "//browsers:firefox-external": {
-            "tags": [
-                "manual",
-                "noci",
-                "requires-network",
-            ],
-        },
-        "//browsers:chromium-native": {
-            "local": True,
-        },
-        "//browsers:firefox-native": {
-            "local": True,
-        },
-    },
     browsers = [
-        "//browsers:chrome-external",
         "//browsers:chromium-native",
-        "//browsers:firefox-external",
         "//browsers:firefox-native",
         "//browsers:phantomjs",
     ],
-    tags = ["noci"],
+    local = True,
     test = ":WebTestTest_wrapped",
 )

--- a/javatests/com/google/testing/web/BUILD
+++ b/javatests/com/google/testing/web/BUILD
@@ -43,5 +43,6 @@ web_test_suite(
         "//browsers:phantomjs",
     ],
     local = True,
+    tags = ["noci"],
     test = ":WebTestTest_wrapped",
 )

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -49,35 +49,11 @@ py_test(
 
 web_test_suite(
     name = "webtest_test",
-    browser_overrides = {
-        "//browsers:chrome-external": {
-            "tags": [
-                "manual",
-                "noci",
-                "requires-network",
-            ],
-        },
-        "//browsers:firefox-external": {
-            "tags": [
-                "manual",
-                "noci",
-                "requires-network",
-            ],
-        },
-        "//browsers:chromium-native": {
-            "local": True,
-        },
-        "//browsers:firefox-native": {
-            "local": True,
-        },
-    },
     browsers = [
-        "//browsers:chrome-external",
         "//browsers:chromium-native",
-        "//browsers:firefox-external",
         "//browsers:firefox-native",
         "//browsers:phantomjs",
     ],
-    tags = ["noci"],
+    local = True,
     test = ":webtest_test_wrapped",
 )

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -55,5 +55,6 @@ web_test_suite(
         "//browsers:phantomjs",
     ],
     local = True,
+    tags = ["noci"],
     test = ":webtest_test_wrapped",
 )


### PR DESCRIPTION
- Remove -external browsers from tests.
- Run all browsers local.
- Remove noci tags.