### PR TITLE
Make rules consistent.

### DIFF
--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -46,37 +46,39 @@ def _browser_impl(ctx):
 
 browser = rule(
     attrs={
-        "metadata":
-            attr.label(
-                mandatory=True, allow_single_file=[".json"], cfg="data"),
-        "deps":
-            attr.label_list(providers=["web_test"]),
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
+        "deps":
+            attr.label_list(providers=["web_test"]),
         "disabled":
             attr.string(),
         "environment":
             attr.string_dict(),
-        "required_tags":
-            attr.string_list(),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
                 default=Label("//go/metadata:merger")),
+        "metadata":
+            attr.label(
+                mandatory=True, allow_single_file=[".json"], cfg="data"),
+        "required_tags":
+            attr.string_list(),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
     implementation=_browser_impl)
 """Defines a browser configuration for use with web_test.
 
 Args:
-  metadata: The web_test metadata file that defines how this browser
-    is launched and default capabilities for this browser.
-  data: Runtime dependencies needed for this browser.
+  data: Runtime dependencies for this configuration.
+  deps: Other web_test-related rules that this rule depends on.
   disabled: If set, then a no-op test will be run for all tests using
     this browser.
-  environment: Map of environment variables-values to set for this browser.
+  environment: Map of environment variables-values to set for this browser.  
+  merger: Metadata merger executable.  
+  metadata: The web_test metadata file that defines how this browser
+    is launched and default capabilities for this browser.  
   required_tags: A list of tags that all web_tests using this browser
     should have. Examples include "requires-network", "local", etc.
 """

--- a/web/internal/metadata.bzl
+++ b/web/internal/metadata.bzl
@@ -42,9 +42,9 @@ def _merge_files(ctx, merger, output, inputs):
 
 def _create_file(ctx,
                  output,
+                 browser_label=None,
                  capabilities=None,
                  environment=None,
-                 browser_label=None,
                  test_label=None,
                  web_test_files=None,
                  extension=None):
@@ -53,11 +53,13 @@ def _create_file(ctx,
   Args:
     ctx: a Skylark rule context.
     output: File object. The file to write the metadata to.
+    browser_label: Label. The label for a browser rule.    
+    capabilities: struct; Browser capabilities.
     environment: string. The Web Test Launcher environment name.
-    browser_label: Label. The label for a browser rule.
     test_label: Label. The label for the test being executed.
-    web_test_files: sequence of web_test_file structs. The named files needed
-      for this configuration.
+    web_test_files: sequence of web_test_file structs.
+    extension: map or struct defining additional fields that should be added
+      metadata file.
   """
   fields = {}
 

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -127,9 +127,6 @@ def _generate_default_test(ctx):
 
 web_test = rule(
     attrs={
-        "test":
-            attr.label(
-                cfg="data", executable=True, mandatory=True),
         "browser":
             attr.label(
                 cfg="data", mandatory=True, providers=["web_test"]),
@@ -139,24 +136,25 @@ web_test = rule(
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
+        "launcher":
+            attr.label(
+                cfg="data", executable=True),
         "merger":
             attr.label(
                 cfg="host",
                 executable=True,
                 default=Label("//go/metadata:merger")),
-        "launcher":
+        "noop_web_test_template":
+            attr.label(
+                allow_single_file=True,
+                default=Label("//web/internal:noop_web_test.sh.template")),
+        "test":
             attr.label(
                 cfg="data", executable=True, mandatory=True),
         "web_test_template":
             attr.label(
-                allow_files=True,
-                single_file=True,
+                allow_single_file=True,
                 default=Label("//web/internal:web_test.sh.template")),
-        "noop_web_test_template":
-            attr.label(
-                allow_files=True,
-                single_file=True,
-                default=Label("//web/internal:noop_web_test.sh.template")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json",},
     test=True,
@@ -164,9 +162,15 @@ web_test = rule(
 """Runs a provided test against a provided browser configuration.
 
 Args:
-  test: The test that will be run against the provided browser.
   browser: A browser configuration that defines the type of browser used for
     this test.
   config: Additional configuration that overrides the configuration in browser.
   data: Additional runtime dependencies for the test.
+  launcher: The web test launcher binary.
+  merger: The metadata merger binary.
+  noop_web_test_template: Shell template used to launch test when browser is
+    disabled.
+  test: The test that will be run against the provided browser.
+  web_test_template: Shell template used to launch test when browser is not
+    disabled.
 """

--- a/web/internal/web_test_archive.bzl
+++ b/web/internal/web_test_archive.bzl
@@ -50,7 +50,17 @@ web_test_archive = rule(
     attrs={
         "archive":
             attr.label(
-                allow_single_file=True, cfg="data", mandatory=True),
+                allow_single_file=[
+                    ".tar",
+                    ".tar.bz2",
+                    ".tbz2",
+                    ".tar.gz",
+                    ".tgz",
+                    ".tar.Z",
+                    ".zip",
+                ],
+                cfg="data",
+                mandatory=True),
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),

--- a/web/internal/web_test_archive.bzl
+++ b/web/internal/web_test_archive.bzl
@@ -11,20 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""A rule for configuring archives that contain named files.
+
+DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
+"""
 
 load("//web/internal:metadata.bzl", "metadata")
 
 
 def _web_test_archive_impl(ctx):
+  patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
   metadata.create_file(
       ctx=ctx,
-      output=ctx.outputs.web_test_metadata,
+      output=patch,
       web_test_files=[
           metadata.web_test_files(
               ctx=ctx,
               archive_file=ctx.file.archive,
               named_files=ctx.attr.named_files),
       ])
+
+  metadata_files = [patch] + [dep.web_test.metadata for dep in ctx.attr.deps]
+
+  metadata.merge_files(
+      ctx=ctx,
+      merger=ctx.executable.merger,
+      output=ctx.outputs.web_test_metadata,
+      inputs=metadata_files)
 
   return struct(
       runfiles=ctx.runfiles(
@@ -38,8 +51,18 @@ web_test_archive = rule(
         "archive":
             attr.label(
                 allow_single_file=True, cfg="data", mandatory=True),
+        "data":
+            attr.label_list(
+                allow_files=True, cfg="data"),
+        "deps":
+            attr.label_list(providers=["web_test"]),
+        "merger":
+            attr.label(
+                executable=True,
+                cfg="host",
+                default=Label("//go/metadata:merger")),
         "named_files":
-            attr.string_dict(mandatory=True)
+            attr.string_dict(mandatory=True),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},)
 """Specifies an archive file with named files in it.
@@ -48,6 +71,9 @@ The archive will be unzipped only if Web Test Launcher wants one the named
 files in the archive.
 
 Args:
-  archive: label referring to the archive file.
-  named_files: a map of names used by Web Test Launcher to path in the archive.
+  archive: Archive file that contains named files.
+  data: Runtime dependencies for this rule.
+  deps: Other web_test-related rules that this rule depends on.
+  merger: Metadata merger executable.
+  named_files: A map of names to paths in the archive.
 """

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -48,26 +48,27 @@ def _web_test_config_impl(ctx):
 
 web_test_config = rule(
     attrs={
-        "metadata":
-            attr.label(allow_single_file=[".json"]),
-        "deps":
-            attr.label_list(providers=["web_test"]),
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
+        "deps":
+            attr.label_list(providers=["web_test"]),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
                 default=Label("//go/metadata:merger")),
+        "metadata":
+            attr.label(allow_single_file=[".json"]),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
     implementation=_web_test_config_impl)
 """A browser-independent configuration that can be used across multiple web_tests.
 
 Args:
+  data: Runtime dependencies for this configuration.
   deps: Other web_test-related rules that this rule depends on.
+  merger: Metadata merger executable.
   metadata: A web_test metadata file with configuration that will override
     all other configuration.
-  data: Additional files that this web_test_config depends on at runtime.
 """

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""A rule for defining executables that can be located by name.
+
+DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
+"""
 
 load("//web/internal:metadata.bzl", "metadata")
 
@@ -47,14 +51,14 @@ web_test_named_executable = rule(
     attrs={
         "alt_name":
             attr.string(),
-        "executable":
-            attr.label(
-                allow_files=True, executable=True, cfg="data", mandatory=True),
-        "deps":
-            attr.label_list(providers=["web_test"]),
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
+        "deps":
+            attr.label_list(providers=["web_test"]),
+        "executable":
+            attr.label(
+                allow_files=True, executable=True, cfg="data", mandatory=True),
         "merger":
             attr.label(
                 executable=True,
@@ -67,7 +71,8 @@ web_test_named_executable = rule(
 
 Args:
   alt_name: If supplied, is used instead of name to lookup the executable.
-  executable: The executable that will be returned for name or alt_name.
-  deps: Other web_test-related rules that this rule depends on.
   data: Runtime dependencies for the executable.
+  deps: Other web_test-related rules that this rule depends on.
+  executable: The executable that will be returned for name or alt_name.
+  merger: Metadata merger executable.
 """

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""A rule for defining files that can be located by name.
+
+DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
+"""
 
 load("//web/internal:metadata.bzl", "metadata")
 
@@ -42,14 +46,14 @@ web_test_named_file = rule(
     attrs={
         "alt_name":
             attr.string(),
-        "file":
-            attr.label(
-                allow_single_file=True, cfg="data", mandatory=True),
-        "deps":
-            attr.label_list(providers=["web_test"]),
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
+        "deps":
+            attr.label_list(providers=["web_test"]),
+        "file":
+            attr.label(
+                allow_single_file=True, cfg="data", mandatory=True),
         "merger":
             attr.label(
                 executable=True,
@@ -58,11 +62,12 @@ web_test_named_file = rule(
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
     implementation=_web_test_named_file_impl)
-"""Defines a executable that can be located by name.
+"""Defines a file that can be located by name.
 
 Args:
   alt_name: If supplied, is used instead of name to lookup the file.
-  file: The file that will be returned for name or alt_name.
-  deps: Other web_test-related rules that this rule depends on.
   data: Runtime dependencies for the file.
+  deps: Other web_test-related rules that this rule depends on.
+  file: The file that will be returned for name or alt_name.
+  merger: Metadata merger executable.
 """


### PR DESCRIPTION
- Add data and deps to web_test_archive.
- Sort attributes in rule definitions and doc strings.