### PR TITLE
Update rules_go to the 0.3.2 release.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,9 +18,9 @@ workspace(name = "io_bazel_rules_webtesting")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "0c0ec7b9c7935883cbfb2df48fbf524e857859a5c05ae1b24d5442956e6bb5e8",
-    strip_prefix = "rules_go-0.2.0",
-    url = "https://github.com/bazelbuild/rules_go/archive/0.2.0.tar.gz",
+    sha256 = "890e055a9956daa85287ed309e8efaa9d5336b2bc5a71ad3676c220c99015a9d",
+    strip_prefix = "rules_go-0.3.2",
+    url = "https://github.com/bazelbuild/rules_go/archive/0.3.2.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")


### PR DESCRIPTION
This is needed to fix an issue with a new Bazel feature, see bazelbuild/bazel#2226 for context.