### PR TITLE
Update webdriver.go to support W3C-style errors.

### DIFF
--- a/browsers/firefox-native.json
+++ b/browsers/firefox-native.json
@@ -2,8 +2,8 @@
     "environment": "firefox",
     "capabilities": {
         "browserName": "firefox",
-		"moz:firefoxOptions": {
-			"binary": "%FIREFOX%"
-		}		
+        "moz:firefoxOptions": {
+            "binary": "%FIREFOX%"
+        }
     }
-}
+} 

--- a/browsers/firefox-native.json
+++ b/browsers/firefox-native.json
@@ -2,9 +2,8 @@
     "environment": "firefox",
     "capabilities": {
         "browserName": "firefox",
-        "firefox_binary": "%FIREFOX%",
-		"firefoxOptions": {
+		"moz:firefoxOptions": {
 			"binary": "%FIREFOX%"
-		}
+		}		
     }
 }

--- a/go/launcher/proxy/BUILD
+++ b/go/launcher/proxy/BUILD
@@ -60,7 +60,10 @@ go_library(
 
 go_library(
     name = "webdriver",
-    srcs = ["webdriver.go"],
+    srcs = [
+        "webdriver.go",
+        "webdriver_error.go",
+    ],
     visibility = ["//go:__subpackages__"],
     deps = [
         "//go/launcher:errors",
@@ -100,4 +103,21 @@ go_web_test_suite(
         "//go/util:bazel",
         "@com_github_tebeka_selenium//:selenium",
     ],
+)
+
+go_web_test_suite(
+    name = "webdriver_test",
+    size = "large",
+    srcs = ["webdriver_test.go"],
+    browsers = [
+        "//browsers:chromium-native",
+        "//browsers:firefox-native",
+    ],
+    go_test_tags = [
+        "manual",
+        "noci",
+    ],
+    library = ":webdriver",
+    local = True,
+    tags = ["noci"],
 )

--- a/go/launcher/proxy/screenshot.go
+++ b/go/launcher/proxy/screenshot.go
@@ -50,7 +50,7 @@ func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interf
 		if err != nil {
 			body, _ := webdriver.MarshalError(err)
 			return driverhub.Response{
-				Status: http.StatusInternalServerError,
+				Status: webdriver.ErrorHTTPStatus(err),
 				Body:   body,
 			}, nil
 		}
@@ -63,7 +63,7 @@ func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interf
 		if err := session.ExecuteScript(ctx, sizeScript, nil, &val); err != nil {
 			body, _ := webdriver.MarshalError(err)
 			return driverhub.Response{
-				Status: http.StatusInternalServerError,
+				Status: webdriver.ErrorHTTPStatus(err),
 				Body:   body,
 			}, nil
 		}
@@ -72,7 +72,7 @@ func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interf
 		if err != nil {
 			body, _ := webdriver.MarshalError(err)
 			return driverhub.Response{
-				Status: http.StatusInternalServerError,
+				Status: webdriver.ErrorHTTPStatus(err),
 				Body:   body,
 			}, nil
 		}
@@ -82,7 +82,7 @@ func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interf
 		if err := png.Encode(base64.NewEncoder(base64.StdEncoding, buffer), cropped); err != nil {
 			body, _ := webdriver.MarshalError(err)
 			return driverhub.Response{
-				Status: http.StatusInternalServerError,
+				Status: webdriver.ErrorHTTPStatus(err),
 				Body:   body,
 			}, nil
 		}

--- a/go/launcher/proxy/screenshot_test.go
+++ b/go/launcher/proxy/screenshot_test.go
@@ -72,7 +72,7 @@ func TestScreenshot(t *testing.T) {
 		return
 	}
 
-	if config.Width != 480 || config.Height != 800 {
-		t.Errorf("got size == %d, %d, expected 480, 800", config.Width, config.Height)
+	if config.Width != 200 || config.Height != 200 {
+		t.Errorf("got size == %d, %d, expected 200, 200", config.Width, config.Height)
 	}
 }

--- a/go/launcher/proxy/screenshot_test.json
+++ b/go/launcher/proxy/screenshot_test.json
@@ -4,8 +4,8 @@
       "mobileEmulation": {
         "userAgent": "Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; Nexus S Build/GRI20) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
         "deviceMetrics": {
-          "height": 800,
-          "width": 480
+          "height": 200,
+          "width": 200
         }
       }
     }

--- a/go/launcher/proxy/webdriver_error.go
+++ b/go/launcher/proxy/webdriver_error.go
@@ -1,0 +1,226 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webdriver
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type errorDatum struct {
+	Status     int
+	Error      string
+	HTTPStatus int
+	W3C        bool
+}
+
+var errorData = []errorDatum{
+	{
+		0, "Success", 200, false,
+	},
+	{
+		6, "invalid session id", 404, true,
+	},
+	{
+		7, "no such element", 404, true,
+	},
+	{
+		8, "no such frame", 404, true,
+	},
+	{
+		9, "unknown command", 404, true,
+	},
+	{
+		10, "stale element reference", 400, true,
+	},
+	{
+		11, "ElementNotVisible", 400, false,
+	},
+	{
+		12, "invalid element state", 400, true,
+	},
+	{
+		13, "unknown error", 500, true,
+	},
+	{
+		15, "element not selectable", 400, true,
+	},
+	{
+		17, "javascript error", 500, true,
+	},
+	{
+		19, "XPathLookupError", 400, false,
+	},
+	{
+		21, "timeout", 408, true,
+	},
+	{
+		23, "no such window", 400, true,
+	},
+	{
+		24, "invalid cookie domain", 400, true,
+	},
+	{
+		25, "unable to set cookie", 500, true,
+	},
+	{
+		26, "unexpected alert open", 500, true,
+	},
+	{
+		27, "no such alert", 400, true,
+	},
+	{
+		28, "script timeout", 408, true,
+	},
+	{
+		29, "invalid element coordinates", 400, true,
+	},
+	{
+		30, "IMENotAvailable", 500, false,
+	},
+	{
+		31, "IMEEngineActivationFailed", 500, false,
+	},
+	{
+		32, "invalid selector", 400, true,
+	},
+	{
+		33, "session not created", 500, true,
+	},
+	{
+		34, "move target out of bounds", 400, true,
+	},
+	{
+		-1, "element not interactable", 400, true,
+	},
+	{
+		-1, "invalid argument", 400, true,
+	},
+	{
+		-1, "no such cookie", 404, true,
+	},
+	{
+		-1, "unable to capture screen", 500, true,
+	},
+	{
+		-1, "unknown method", 405, true,
+	},
+	{
+		-1, "unsupported operation", 500, true,
+	},
+}
+
+type webDriverError struct {
+	errDatum errorDatum
+	value    interface{}
+}
+
+func newWebDriverError(resp *jsonResp) error {
+	if resp.Error != "" {
+		for _, cand := range errorData {
+			if cand.Error == resp.Error {
+				return &webDriverError{cand, resp.Value}
+			}
+		}
+	}
+	if resp.Status != 0 {
+		for _, cand := range errorData {
+			if cand.Status == resp.Status {
+				return &webDriverError{cand, resp.Value}
+			}
+		}
+	}
+
+	return &webDriverError{errorDatum{resp.Status, resp.Error, 500, false}, resp.Value}
+}
+
+func (e *webDriverError) Component() string {
+	return compName
+}
+
+func (e *webDriverError) Error() string {
+	message := e.value
+	if mapValue, ok := message.(map[string]interface{}); ok {
+		if m, ok := mapValue["message"]; ok {
+			message = m
+		}
+	}
+
+	if e.errDatum.W3C {
+		return fmt.Sprintf("[%s] (%s) %v", e.Component(), e.errDatum.Error, message)
+	}
+
+	return fmt.Sprintf("[%s] (%d) %v", e.Component(), e.errDatum.Status, message)
+}
+
+// IsWebDriverError returns true if err is a WebDriver Error.
+func IsWebDriverError(err error) bool {
+	_, ok := err.(*webDriverError)
+	return ok
+}
+
+// ErrorStatus returns the WebDriver status for err.
+func ErrorStatus(err error) int {
+	we, ok := err.(*webDriverError)
+	if !ok {
+		return 13
+	}
+	if we.errDatum.Status <= 0 {
+		return 13
+	}
+	return we.errDatum.Status
+}
+
+// ErrorValue returns the WebDriver value for err.
+func ErrorValue(err error) interface{} {
+	we, ok := err.(*webDriverError)
+	if !ok {
+		return map[string]interface{}{"message": err.Error()}
+	}
+	return we.value
+}
+
+// ErrorError returns the WebDriver error for err.
+func ErrorError(err error) string {
+	we, ok := err.(*webDriverError)
+	if !ok {
+		return "unknown error"
+	}
+	if !we.errDatum.W3C || we.errDatum.Error == "" {
+		return "unknown error"
+	}
+	return we.errDatum.Error
+}
+
+// ErrorHTTPStatus returns the HTTP status code that is associated with err.
+func ErrorHTTPStatus(err error) int {
+	we, ok := err.(*webDriverError)
+	if !ok {
+		return 500
+	}
+	return we.errDatum.HTTPStatus
+
+}
+
+// MarshalError generates the WebDriver JSON wire protocol HTTP response body for err.
+func MarshalError(err error) ([]byte, error) {
+	body := map[string]interface{}{
+		"status": ErrorStatus(err),
+		"value":  ErrorValue(err),
+		"error":  ErrorError(err),
+	}
+
+	return json.Marshal(body)
+}

--- a/go/launcher/proxy/webdriver_test.go
+++ b/go/launcher/proxy/webdriver_test.go
@@ -1,0 +1,224 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webdriver
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCreateSessionAndQuit(t *testing.T) {
+	ctx := context.Background()
+
+	d, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Quit(ctx); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCreateSessionFails(t *testing.T) {
+	ctx := context.Background()
+
+	d, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{
+		"chromeOptions": map[string]interface{}{
+			"binary": "a-binary",
+		},
+		"moz:firefoxOptions": map[string]interface{}{
+			"binary": "a-binary",
+		},
+	})
+	if err == nil {
+		t.Error("got nil err from CreateSession with bad capabilities")
+		d.Quit(ctx)
+	}
+}
+
+func TestHealthy(t *testing.T) {
+	ctx := context.Background()
+
+	d, err := CreateSession(ctx, wdAddress(), 1, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Healthy(ctx); err != nil {
+		t.Error(err)
+	}
+	if err := d.Quit(ctx); err != nil {
+		t.Error(err)
+	}
+	if err := d.Healthy(ctx); err == nil {
+		t.Error("got nil error from Healthy after quit")
+	}
+}
+
+func TestExecuteScript(t *testing.T) {
+	testCases := []struct {
+		script   string
+		args     []interface{}
+		value    int
+		expected int
+		err      bool
+	}{
+		{
+			"return 1 + 2;",
+			[]interface{}{},
+			0,
+			3,
+			false,
+		},
+		{
+			"return arguments[0] + arguments[1];",
+			[]interface{}{1, 2},
+			0,
+			3,
+			false,
+		},
+		{
+			"return argument[0] + arguments[1];",
+			[]interface{}{1, 2},
+			0,
+			0,
+			true,
+		},
+	}
+
+	ctx := context.Background()
+
+	d, err := CreateSession(ctx, wdAddress(), 1, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.script, func(t *testing.T) {
+			if err := d.ExecuteScript(ctx, tc.script, tc.args, &tc.value); err != nil {
+				if !tc.err {
+					t.Errorf("got unexpected err %v for ExecuteScript(%q, %v)", err, tc.script, tc.args)
+				}
+				return
+			}
+			if tc.err {
+				t.Errorf("got nil err for ExecuteScript(%q, %v)", tc.script, tc.args)
+				return
+			}
+			if tc.value != tc.expected {
+				t.Errorf("got %v, expected %v for ExecuteScript(%q, %v)", tc.value, tc.expected, tc.script, tc.args)
+			}
+		})
+	}
+	if err := d.Quit(ctx); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestExecuteScriptAsync(t *testing.T) {
+	testCases := []struct {
+		script   string
+		args     []interface{}
+		value    int
+		expected int
+		err      bool
+	}{
+		{
+			"arguments[0](1 + 2);",
+			[]interface{}{},
+			0,
+			3,
+			false,
+		},
+		{
+			"arguments[2](arguments[0] + arguments[1]);",
+			[]interface{}{1, 2},
+			0,
+			3,
+			false,
+		},
+		{
+			"argument[2](argument[0] + argument[1]);",
+			[]interface{}{1, 2},
+			0,
+			0,
+			true,
+		},
+		{
+			"return 1 + 2;",
+			[]interface{}{1, 2},
+			0,
+			0,
+			true,
+		},
+	}
+
+	ctx := context.Background()
+
+	d, err := CreateSession(ctx, wdAddress(), 1, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.script, func(t *testing.T) {
+			if err := d.ExecuteScriptAsync(ctx, tc.script, tc.args, &tc.value); err != nil {
+				if !tc.err {
+					t.Errorf("got unexpected err %v for ExecuteScriptAsync(%q, %v)", err, tc.script, tc.args)
+				}
+				return
+			}
+			if tc.err {
+				t.Errorf("got nil err for ExecuteScriptAsync(%q, %v)", tc.script, tc.args)
+				return
+			}
+			if tc.value != tc.expected {
+				t.Errorf("got %v, expected %v for ExecuteScriptAsync(%q, %v)", tc.value, tc.expected, tc.script, tc.args)
+			}
+		})
+	}
+	if err := d.Quit(ctx); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestScreenshot(t *testing.T) {
+	ctx := context.Background()
+
+	d, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img, err := d.Screenshot(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	if img == nil {
+		t.Error("got nil, expected an image.Image")
+	}
+	if err := d.Quit(ctx); err != nil {
+		t.Error(err)
+	}
+}
+
+func wdAddress() string {
+	addr := os.Getenv("WEB_TEST_WEBDRIVER_SERVER")
+	if !strings.HasSuffix(addr, "/") {
+		addr = addr + "/"
+	}
+	return addr
+}

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -28,9 +28,7 @@ py_library(
     ),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
-    deps = [
-        "@org_seleniumhq_py//:selenium",
-    ],
+    deps = ["@org_seleniumhq_py//:selenium"],
 )
 
 py_web_test_suite(


### PR DESCRIPTION
- Fix screenshot.go to return W3C-style errors.
- Fix screenshot_test.go to work when running with Xvfb.
- Fix firefox-native.json to conform to what geckodriver expects.