### PR TITLE
Add quit handler that correctly handles close.

### DIFF
--- a/go/launcher/BUILD
+++ b/go/launcher/BUILD
@@ -37,6 +37,7 @@ go_binary(
         "//go/launcher/environments:native",
         "//go/launcher/proxy",
         "//go/launcher/proxy:driverhub",
+        "//go/launcher/proxy:quithandler",        
         "//go/launcher/proxy:screenshot",
         "//go/metadata",
         "//go/util:bazel",

--- a/go/launcher/config.go
+++ b/go/launcher/config.go
@@ -20,12 +20,14 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/launcher/environments/firefox"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/environments/native"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub"
+	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/quithandler"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/screenshot"
 )
 
 func init() {
 	// Configure WebDriver handlers.
 	driverhub.HandlerProviderFunc(screenshot.ProviderFunc)
+	driverhub.HandlerProviderFunc(quithandler.ProviderFunc)
 
 	// Configure Environments.
 	RegisterEnvProviderFunc("external", external.NewEnv)

--- a/go/launcher/proxy/BUILD
+++ b/go/launcher/proxy/BUILD
@@ -72,6 +72,33 @@ go_library(
 )
 
 go_library(
+    name = "quithandler",
+    srcs = ["quit_handler.go"],
+    visibility = ["//go:__subpackages__"],
+    deps = [
+        ":driverhub",
+    ],
+)
+
+go_web_test_suite(
+    name = "quithandler_test",
+    srcs = ["quit_handler_test.go"],
+    browsers = ["//browsers:chromium-native"],
+    data = ["//go/launcher/proxy/testdata:testpage.html"],
+    go_test_tags = [
+        "manual",
+        "noci",
+    ],
+    local = True,
+    tags = ["noci"],
+    deps = [
+        "//go:webtest",
+        "//go/util:bazel",
+        "@com_github_tebeka_selenium//:selenium",
+    ],
+)
+
+go_library(
     name = "screenshot",
     srcs = ["screenshot.go"],
     visibility = ["//go:__subpackages__"],
@@ -92,6 +119,7 @@ go_web_test_suite(
     srcs = ["screenshot_test.go"],
     browsers = ["//browsers:chromium-native"],
     config = ":screenshot_test_config",
+    data = ["//go/launcher/proxy/testdata:testpage.html"],
     go_test_tags = [
         "manual",
         "noci",

--- a/go/launcher/proxy/quit_handler.go
+++ b/go/launcher/proxy/quit_handler.go
@@ -37,20 +37,13 @@ func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interf
 		}
 
 		// If closing last window, then quit.
-		if windows, err := session.GetWindowHandles(ctx); err != nil {
+		if windows, err := session.WindowHandles(ctx); err != nil {
 			return driverhub.ResponseFromError(err)
 		} else if len(windows) == 1 {
 			return session.Quit(ctx, rq)
 		}
 
-		// Otherwise close window
-		if err := session.Close(ctx); err != nil {
-			return driverhub.ResponseFromError(err)
-		}
-
-		return driverhub.Response{
-			Status: http.StatusOK,
-			Body:   []byte(`{"status": 0}`),
-		}, nil
+		// Otherwise forward the close window
+		return base(ctx, rq)
 	}, true
 }

--- a/go/launcher/proxy/quit_handler.go
+++ b/go/launcher/proxy/quit_handler.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package quithandler checks if a window close command is closing the last window and treats it
+// as a quit if it is.
+package quithandler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub"
+)
+
+// ProviderFunc provides a handler for quit and close commands that end the session within the environment when the browser exits.
+func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interface{}, base driverhub.HandlerFunc) (driverhub.HandlerFunc, bool) {
+	return func(ctx context.Context, rq driverhub.Request) (driverhub.Response, error) {
+		// If quit command, then quit.
+		if rq.Method == http.MethodDelete && len(rq.Path) == 0 {
+			return session.Quit(ctx, rq)
+		}
+
+		// If not window close command, then forward as normal
+		if rq.Method != http.MethodDelete || len(rq.Path) != 1 || rq.Path[0] != "window" {
+			return base(ctx, rq)
+		}
+
+		// If closing last window, then quit.
+		if windows, err := session.GetWindowHandles(ctx); err != nil {
+			return driverhub.ResponseFromError(err)
+		} else if len(windows) == 1 {
+			return session.Quit(ctx, rq)
+		}
+
+		// Otherwise close window
+		if err := session.Close(ctx); err != nil {
+			return driverhub.ResponseFromError(err)
+		}
+
+		return driverhub.Response{
+			Status: http.StatusOK,
+			Body:   []byte(`{"status": 0}`),
+		}, nil
+	}, true
+}

--- a/go/launcher/proxy/quit_handler_test.go
+++ b/go/launcher/proxy/quit_handler_test.go
@@ -16,6 +16,7 @@ package quithandler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bazelbuild/rules_webtesting/go/util/bazel"
 	"github.com/bazelbuild/rules_webtesting/go/webtest"
@@ -33,22 +34,18 @@ func TestCloseOneWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Avoid Fatal so that this defer gets called
 	defer driver.Quit()
 
 	if err := driver.Get("file://" + testpage); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := driver.CloseWindow(""); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if _, err := driver.WindowHandles(); err == nil {
-		t.Error("got nil, expected invalid session error")
-		return
+		t.Fatal("got nil, expected invalid session error")
 	}
 }
 
@@ -63,33 +60,27 @@ func TestQuit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Avoid Fatal so that this defer gets called
 	defer driver.Quit()
 
 	if err := driver.Get("file://" + testpage); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	button, err := driver.FindElement("tag name", "input")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := button.Click(); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := driver.Quit(); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if _, err := driver.WindowHandles(); err == nil {
-		t.Error("got nil, expected invalid session error")
-		return
+		t.Fatal("got nil, expected invalid session error")
 	}
 }
 
@@ -104,52 +95,54 @@ func TestCloseTwoWindows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Avoid Fatal so that this defer gets called
 	defer driver.Quit()
 
 	if err := driver.Get("file://" + testpage); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	button, err := driver.FindElement("tag name", "input")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := button.Click(); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		handles, err := driver.WindowHandles()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(handles) == 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	if err := driver.CloseWindow(""); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	handles, err := driver.WindowHandles()
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if len(handles) != 1 {
-		t.Errorf("Got %d handles, expected 1", len(handles))
-		return
+		t.Fatalf("Got %d handles, expected 1", len(handles))
 	}
 
 	if err := driver.SwitchWindow(handles[0]); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := driver.CloseWindow(""); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if _, err := driver.WindowHandles(); err == nil {
-		t.Error("got nil, expected invalid session error")
-		return
+		t.Fatal("got nil, expected invalid session error")
 	}
 }

--- a/go/launcher/proxy/quit_handler_test.go
+++ b/go/launcher/proxy/quit_handler_test.go
@@ -1,0 +1,155 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quithandler
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_webtesting/go/util/bazel"
+	"github.com/bazelbuild/rules_webtesting/go/webtest"
+	"github.com/tebeka/selenium/selenium"
+)
+
+func TestCloseOneWindow(t *testing.T) {
+	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Avoid Fatal so that this defer gets called
+	defer driver.Quit()
+
+	if err := driver.Get("file://" + testpage); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := driver.CloseWindow(""); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if _, err := driver.WindowHandles(); err == nil {
+		t.Error("got nil, expected invalid session error")
+		return
+	}
+}
+
+func TestQuit(t *testing.T) {
+	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Avoid Fatal so that this defer gets called
+	defer driver.Quit()
+
+	if err := driver.Get("file://" + testpage); err != nil {
+		t.Error(err)
+		return
+	}
+
+	button, err := driver.FindElement("tag name", "input")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := button.Click(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := driver.Quit(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if _, err := driver.WindowHandles(); err == nil {
+		t.Error("got nil, expected invalid session error")
+		return
+	}
+}
+
+func TestCloseTwoWindows(t *testing.T) {
+	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Avoid Fatal so that this defer gets called
+	defer driver.Quit()
+
+	if err := driver.Get("file://" + testpage); err != nil {
+		t.Error(err)
+		return
+	}
+
+	button, err := driver.FindElement("tag name", "input")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := button.Click(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := driver.CloseWindow(""); err != nil {
+		t.Error(err)
+		return
+	}
+
+	handles, err := driver.WindowHandles()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(handles) != 1 {
+		t.Errorf("Got %d handles, expected 1", len(handles))
+		return
+	}
+
+	if err := driver.SwitchWindow(handles[0]); err != nil {
+		t.Error(err)
+	}
+
+	if err := driver.CloseWindow(""); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if _, err := driver.WindowHandles(); err == nil {
+		t.Error("got nil, expected invalid session error")
+		return
+	}
+}

--- a/go/launcher/proxy/screenshot_test.go
+++ b/go/launcher/proxy/screenshot_test.go
@@ -40,44 +40,38 @@ func TestScreenshot(t *testing.T) {
 	defer driver.Quit()
 
 	if err := driver.Get("file://" + testpage); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	img, err := driver.Screenshot()
 
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	tmpDir, err := bazel.NewTmpDir("crop_test")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	outPath := filepath.Join(tmpDir, "cropped.png")
 
 	if err := ioutil.WriteFile(outPath, img, 0660); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	check, err := os.Open(outPath)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
+	defer check.Close()
 
 	config, err := png.DecodeConfig(check)
-	check.Close()
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if config.Width != 200 || config.Height != 200 {
-		t.Errorf("got size == %d, %d, expected 200, 200", config.Width, config.Height)
+		t.Fatalf("got size == %d, %d, expected 200, 200", config.Width, config.Height)
 	}
 }

--- a/go/launcher/proxy/screenshot_test.go
+++ b/go/launcher/proxy/screenshot_test.go
@@ -27,6 +27,11 @@ import (
 )
 
 func TestScreenshot(t *testing.T) {
+	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
 	if err != nil {
 		t.Fatal(err)
@@ -34,7 +39,7 @@ func TestScreenshot(t *testing.T) {
 
 	defer driver.Quit()
 
-	if err := driver.Get("http://www.google.com"); err != nil {
+	if err := driver.Get("file://" + testpage); err != nil {
 		t.Error(err)
 		return
 	}

--- a/go/launcher/proxy/testdata/BUILD
+++ b/go/launcher/proxy/testdata/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+package(default_testonly = True)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(
+    glob(["**"]),
+    visibility = ["//go:__subpackages__"],
+)

--- a/go/launcher/proxy/testdata/testpage.html
+++ b/go/launcher/proxy/testdata/testpage.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<title>Test Page</title>
+</head>
+<body>
+<input type="button" value="open new window" onclick="window.open()">
+</body>
+</html>

--- a/go/launcher/proxy/webdriver.go
+++ b/go/launcher/proxy/webdriver.go
@@ -61,10 +61,8 @@ type WebDriver interface {
 	Capabilities() map[string]interface{}
 	// Screenshot takes a screenshot of the current browser window.
 	Screenshot(ctx context.Context) (image.Image, error)
-	// GetWindowHandles returns a slice of the current window handles.
-	GetWindowHandles(ctx context.Context) ([]string, error)
-	// Close closes the current window.
-	Close(ctx context.Context) error
+	// WindowHandles returns a slice of the current window handles.
+	WindowHandles(ctx context.Context) ([]string, error)
 }
 
 // LogEntry is an entry parsed from the logs retrieved from the remote WebDriver.
@@ -219,18 +217,13 @@ func (d *webDriver) Screenshot(ctx context.Context) (image.Image, error) {
 	return png.Decode(base64.NewDecoder(base64.StdEncoding, strings.NewReader(value)))
 }
 
-// GetWindowHandles returns a slice of the current window handles.
-func (d *webDriver) GetWindowHandles(ctx context.Context) ([]string, error) {
+// WindowHandles returns a slice of the current window handles.
+func (d *webDriver) WindowHandles(ctx context.Context) ([]string, error) {
 	var value []string
 	if err := d.get(ctx, "window_handles", &value); err != nil {
 		return nil, err
 	}
 	return value, nil
-}
-
-// Close closes the current window.
-func (d *webDriver) Close(ctx context.Context) error {
-	return d.delete(ctx, "window", nil)
 }
 
 func (d *webDriver) post(ctx context.Context, suffix string, body interface{}, value interface{}) error {

--- a/go/launcher/proxy/webdriver.go
+++ b/go/launcher/proxy/webdriver.go
@@ -61,6 +61,10 @@ type WebDriver interface {
 	Capabilities() map[string]interface{}
 	// Screenshot takes a screenshot of the current browser window.
 	Screenshot(ctx context.Context) (image.Image, error)
+	// GetWindowHandles returns a slice of the current window handles.
+	GetWindowHandles(ctx context.Context) ([]string, error)
+	// Close closes the current window.
+	Close(ctx context.Context) error
 }
 
 // LogEntry is an entry parsed from the logs retrieved from the remote WebDriver.
@@ -213,6 +217,20 @@ func (d *webDriver) Screenshot(ctx context.Context) (image.Image, error) {
 		return nil, err
 	}
 	return png.Decode(base64.NewDecoder(base64.StdEncoding, strings.NewReader(value)))
+}
+
+// GetWindowHandles returns a slice of the current window handles.
+func (d *webDriver) GetWindowHandles(ctx context.Context) ([]string, error) {
+	var value []string
+	if err := d.get(ctx, "window_handles", &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+// Close closes the current window.
+func (d *webDriver) Close(ctx context.Context) error {
+	return d.delete(ctx, "window", nil)
 }
 
 func (d *webDriver) post(ctx context.Context, suffix string, body interface{}, value interface{}) error {

--- a/go/launcher/proxy/webdriver_test.go
+++ b/go/launcher/proxy/webdriver_test.go
@@ -105,7 +105,7 @@ func TestExecuteScript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	defer d.Quit(ctx)
 	for _, tc := range testCases {
 		t.Run(tc.script, func(t *testing.T) {
 			if err := d.ExecuteScript(ctx, tc.script, tc.args, &tc.value); err != nil {
@@ -122,9 +122,6 @@ func TestExecuteScript(t *testing.T) {
 				t.Errorf("got %v, expected %v for ExecuteScript(%q, %v)", tc.value, tc.expected, tc.script, tc.args)
 			}
 		})
-	}
-	if err := d.Quit(ctx); err != nil {
-		t.Error(err)
 	}
 }
 
@@ -172,6 +169,7 @@ func TestExecuteScriptAsync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer d.Quit(ctx)
 
 	for _, tc := range testCases {
 		t.Run(tc.script, func(t *testing.T) {
@@ -190,9 +188,6 @@ func TestExecuteScriptAsync(t *testing.T) {
 			}
 		})
 	}
-	if err := d.Quit(ctx); err != nil {
-		t.Error(err)
-	}
 }
 
 func TestScreenshot(t *testing.T) {
@@ -202,16 +197,44 @@ func TestScreenshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer d.Quit(ctx)
 
 	img, err := d.Screenshot(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if img == nil {
-		t.Error("got nil, expected an image.Image")
+		t.Fatal("got nil, expected an image.Image")
 	}
-	if err := d.Quit(ctx); err != nil {
-		t.Error(err)
+}
+
+func TestWindowHandles(t *testing.T) {
+	ctx := context.Background()
+
+	driver, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer driver.Quit(ctx)
+
+	if windows, err := driver.WindowHandles(ctx); err != nil {
+		t.Fatal(err)
+	} else if len(windows) != 1 {
+		t.Fatalf("Got %d handles, expected 1", len(windows))
+	}
+}
+
+func TestQuit(t *testing.T) {
+	ctx := context.Background()
+
+	driver, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver.Quit(ctx)
+
+	if _, err := driver.WindowHandles(ctx); err == nil {
+		t.Fatal("Got nil err, expected unknown session err")
 	}
 }
 


### PR DESCRIPTION
- If last window is closed, WebDriver treats this the same as quitting.
  However, WTL had no way to tell this, so catching Close commands and
  checking to see if last window is going to be closed, and, if so,
  calling quit.