### PR TITLE
Improvements to launcher Run.

### DIFF
--- a/go/launcher/BUILD
+++ b/go/launcher/BUILD
@@ -30,6 +30,7 @@ go_binary(
     deps = [
         ":cmdhelper",
         ":diagnostics",
+        ":errors",
         "//go/launcher/environments:chrome",
         "//go/launcher/environments:environment",
         "//go/launcher/environments:external",


### PR DESCRIPTION
- Don't block starting test on environment being running.
- Catch and cleanly exit if test is interrupted (CTRL-C or bazel
timeout).
- Only call env.TearDown() if env.SetUp() completes successfully.