### PR TITLE
Cleanup external deps

### DIFF
--- a/build_files/com_github_gorilla_mux.BUILD
+++ b/build_files/com_github_gorilla_mux.BUILD
@@ -14,15 +14,27 @@
 #
 ################################################################################
 #
-licenses(["notice"])  # Apache 2
+licenses(["notice"])
 
-py_library(
-    name = "selenium",
-    srcs = glob(["**/*.py"]),
-    data = glob(
-        ["**/*"],
-        exclude = ["**/*.py"],
-    ),
-    srcs_version = "PY2AND3",
+exports_files(["LICENSE"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library")
+
+go_prefix("github.com/gorilla/mux")
+
+go_library(
+    name = "mux",
+    srcs = [
+        "context_native.go",
+        "doc.go",
+        "mux.go",
+        "regexp.go",
+        "route.go",
+    ],
+)
+
+alias(
+    name = "com_github_gorilla_mux",
+    actual = ":mux",
     visibility = ["//visibility:public"],
 )

--- a/build_files/com_github_tebeka_selenium.BUILD
+++ b/build_files/com_github_tebeka_selenium.BUILD
@@ -14,22 +14,24 @@
 #
 ################################################################################
 #
-licenses(["notice"])
+licenses(["notice"])  # MIT.
 
 exports_files(["LICENSE"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library")
 
-go_prefix("github.com/gorilla/mux")
+go_prefix("github.com/tebeka/selenium")
 
 go_library(
-    name = "mux",
-    srcs = [
-        "context_native.go",
-        "doc.go",
-        "mux.go",
-        "regexp.go",
-        "route.go",
-    ],
+    name = "selenium",
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
+)
+
+alias(
+    name = "com_github_tebeka_selenium",
+    actual = ":selenium",
     visibility = ["//visibility:public"],
 )

--- a/build_files/org_seleniumhq_py.BUILD
+++ b/build_files/org_seleniumhq_py.BUILD
@@ -14,19 +14,15 @@
 #
 ################################################################################
 #
-licenses(["notice"])  # MIT.
+licenses(["notice"])  # Apache 2
 
-exports_files(["LICENSE"])
-
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library")
-
-go_prefix("github.com/tebeka/selenium")
-
-go_library(
-    name = "selenium",
-    srcs = glob(
-        ["*.go"],
-        exclude = ["*_test.go"],
+py_library(
+    name = "org_seleniumhq_py",
+    srcs = glob(["**/*.py"]),
+    data = glob(
+        ["**/*"],
+        exclude = ["**/*.py"],
     ),
+    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )

--- a/go/BUILD
+++ b/go/BUILD
@@ -28,7 +28,7 @@ go_library(
     deps = [
         "//go/metadata",
         "//go/util:bazel",
-        "@com_github_tebeka_selenium//:selenium",
+        "@com_github_tebeka_selenium",
     ],
 )
 
@@ -53,5 +53,5 @@ go_web_test_suite(
     library = ":webtest",
     local = True,
     tags = ["noci"],
-    deps = ["@com_github_tebeka_selenium//:selenium"],
+    deps = ["@com_github_tebeka_selenium"],
 )

--- a/go/launcher/proxy/BUILD
+++ b/go/launcher/proxy/BUILD
@@ -54,7 +54,7 @@ go_library(
         "//go/launcher/environments:environment",
         "//go/metadata",
         "//go/util:httphelper",
-        "@com_github_gorilla_mux//:mux",
+        "@com_github_gorilla_mux",
     ],
 )
 
@@ -94,7 +94,7 @@ go_web_test_suite(
     deps = [
         "//go:webtest",
         "//go/util:bazel",
-        "@com_github_tebeka_selenium//:selenium",
+        "@com_github_tebeka_selenium",
     ],
 )
 
@@ -141,7 +141,7 @@ go_web_test_suite(
     deps = [
         "//go:webtest",
         "//go/util:bazel",
-        "@com_github_tebeka_selenium//:selenium",
+        "@com_github_tebeka_selenium",
     ],
 )
 

--- a/go/screenshotter/BUILD
+++ b/go/screenshotter/BUILD
@@ -16,6 +16,8 @@
 #
 package(default_testonly = True)
 
+licenses(["notice"])  # Apache 2.0
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//web:go.bzl", "go_web_test_suite")
 
@@ -24,7 +26,7 @@ go_library(
     srcs = ["screenshotter.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_tebeka_selenium//:selenium",
+        "@com_github_tebeka_selenium",
     ],
 )
 
@@ -43,6 +45,6 @@ go_web_test_suite(
     deps = [
         "//go:webtest",
         "//go/util:bazel",
-        "@com_github_tebeka_selenium//:selenium",
+        "@com_github_tebeka_selenium",
     ],
 )

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -28,7 +28,7 @@ py_library(
     ),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
-    deps = ["@org_seleniumhq_py//:selenium"],
+    deps = ["@org_seleniumhq_py"],
 )
 
 py_web_test_suite(

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -139,7 +139,7 @@ def cglib_nodep():
 def com_github_gorilla_mux():
   native.new_http_archive(
       name = "com_github_gorilla_mux",
-      build_file = str(Label("//build_files:gorilla_mux.BUILD")),
+      build_file = str(Label("//build_files:com_github_gorilla_mux.BUILD")),
       sha256 = "a32c13a36c58cb321136231ae8b67b0c6ad3c5f462e65eb6771f59c44b44ccba",
       strip_prefix = "mux-757bef944d0f21880861c2dd9c871ca543023cba",
       urls = [
@@ -152,7 +152,7 @@ def com_github_gorilla_mux():
 def com_github_tebeka_selenium():
   native.new_http_archive(
       name = "com_github_tebeka_selenium",
-      build_file = str(Label("//build_files:selenium_go.BUILD")),
+      build_file = str(Label("//build_files:com_github_tebeka_selenium.BUILD")),
       sha256 = "c33decb47a9b81d5221cda29c8f040ca5cf874956bbb002ef82b06e07ed78c3d",
       strip_prefix = "selenium-f6f9a3638fa049f85b0aaf42e693e1c4ab257d4f",
       urls = [
@@ -422,7 +422,7 @@ def org_mozilla_geckodriver():
 def org_seleniumhq_py():
   native.new_http_archive(
       name = "org_seleniumhq_py",
-      build_file = str(Label("//build_files:selenium_py.BUILD")),
+      build_file = str(Label("//build_files:org_seleniumhq_py.BUILD")),
       sha256 = "85daad4d09be86bddd4f45579986ac316c1909c3b4653ed471ea4519eb413c8f",
       strip_prefix = "selenium-3.0.2/py",
       urls = [


### PR DESCRIPTION
- Create targets with same name as repository to shorten deps.
- Rename .BUILD files to match repository names.