### PR TITLE
Update to work with Sauce OnDemand plugin.

### DIFF
--- a/browsers/BUILD
+++ b/browsers/BUILD
@@ -16,9 +16,9 @@
 #
 package(default_testonly = True)
 
-load("//web:web.bzl", "browser")
-
 licenses(["notice"])  # Apache 2.0
+
+load("//web:web.bzl", "browser")
 
 config_setting(
     name = "mac",
@@ -35,13 +35,6 @@ config_setting(
 browser(
     name = "firefox-external",
     metadata = "firefox-external.json",
-    required_tags = ["requires-network"],
-    visibility = ["//visibility:public"],
-)
-
-browser(
-    name = "chrome55-win10-sauce",
-    metadata = "chrome55-win10-sauce.json",
     required_tags = ["requires-network"],
     visibility = ["//visibility:public"],
 )

--- a/browsers/chrome55-win10-sauce.json
+++ b/browsers/chrome55-win10-sauce.json
@@ -1,9 +1,0 @@
-{
-    "environment": "sauce",
-    "capabilities": {
-        "browserName": "chrome",
-        "platform": "Windows 10",
-        "tunnel-identifier": "${TUNNEL_IDENTIFIER}",        
-        "version": "55.0"
-    }
-}

--- a/browsers/sauce/BUILD
+++ b/browsers/sauce/BUILD
@@ -18,26 +18,11 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//web:web.bzl", "browser")
 
-go_library(
-    name = "go_default_library",
-    srcs = ["merger.go"],
-    visibility = ["//visibility:private"],
-    deps = ["//go/metadata:go_default_library"],
-)
-
-go_binary(
-    name = "main",
-    library = ":go_default_library",
+browser(
+    name = "chrome55-win10",
+    metadata = "chrome55-win10.json",
+    required_tags = ["requires-network"],
     visibility = ["//visibility:public"],
-)
-
-sh_test(
-    name = "merger_test",
-    srcs = ["merger_test.sh"],
-    data = [
-        ":main",
-        "//go/metadata/testdata",
-    ],
 )

--- a/browsers/sauce/chrome55-win10.json
+++ b/browsers/sauce/chrome55-win10.json
@@ -1,0 +1,12 @@
+{
+    "environment": "sauce",
+    "capabilities": {
+        "browserName": "chrome",
+        "platform": "Windows 10",
+        "version": "55.0",
+        "name": "%LABEL%",
+        "build": "${BUILD_TAG}",
+        "tags": ["%ENVIRONMENT%", "%TEST_LABEL%", "%BROWSER_LABEL%", "%CONFIG_LABEL%"],
+        "tunnel-identifier": "${TUNNEL_IDENTIFIER}"
+    }
+}

--- a/go/launcher/proxy/driverhub/quithandler/BUILD
+++ b/go/launcher/proxy/driverhub/quithandler/BUILD
@@ -31,17 +31,18 @@ go_library(
 go_web_test_suite(
     name = "quit_handler_test",
     srcs = ["quit_handler_test.go"],
-    browsers = ["//browsers:chromium-native"],
-    data = ["//go/launcher/proxy/testdata:testpage.html"],
+    browsers = ["//browsers/sauce:chrome55-win10"],
+    data = ["//go/launcher/proxy/testdata"],
     go_test_tags = [
         "manual",
         "noci",
     ],
     library = ":go_default_library",
     local = True,
-    tags = ["noci"],
+    tags = ["requires-network"],
     deps = [
         "//go/bazel:go_default_library",
+        "//go/portpicker:go_default_library",
         "//go/webtest:go_default_library",
         "@com_github_tebeka_selenium//:go_default_library",
     ],

--- a/go/launcher/proxy/driverhub/quithandler/quit_handler_test.go
+++ b/go/launcher/proxy/driverhub/quithandler/quit_handler_test.go
@@ -15,20 +15,45 @@
 package quithandler
 
 import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/bazelbuild/rules_webtesting/go/bazel"
+	"github.com/bazelbuild/rules_webtesting/go/portpicker"
 	"github.com/bazelbuild/rules_webtesting/go/webtest"
 	"github.com/tebeka/selenium"
 )
 
-func TestCloseOneWindow(t *testing.T) {
-	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
+var testpage = ""
+
+func TestMain(m *testing.M) {
+	port, err := portpicker.PickUnusedPort()
 	if err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
 
+	dir, err := bazel.RunfilesPath()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dir = filepath.Join(dir, bazel.TestWorkspace())
+
+	go func() {
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), http.FileServer(http.Dir(dir))))
+	}()
+
+	testpage = fmt.Sprintf("http://localhost:%d/go/launcher/proxy/testdata/testpage.html", port)
+
+	os.Exit(m.Run())
+}
+
+func TestCloseOneWindow(t *testing.T) {
 	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +61,7 @@ func TestCloseOneWindow(t *testing.T) {
 
 	defer driver.Quit()
 
-	if err := driver.Get("file://" + testpage); err != nil {
+	if err := driver.Get(testpage); err != nil {
 		t.Fatal(err)
 	}
 
@@ -50,11 +75,6 @@ func TestCloseOneWindow(t *testing.T) {
 }
 
 func TestQuit(t *testing.T) {
-	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +82,7 @@ func TestQuit(t *testing.T) {
 
 	defer driver.Quit()
 
-	if err := driver.Get("file://" + testpage); err != nil {
+	if err := driver.Get(testpage); err != nil {
 		t.Fatal(err)
 	}
 
@@ -85,11 +105,6 @@ func TestQuit(t *testing.T) {
 }
 
 func TestCloseTwoWindows(t *testing.T) {
-	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +112,7 @@ func TestCloseTwoWindows(t *testing.T) {
 
 	defer driver.Quit()
 
-	if err := driver.Get("file://" + testpage); err != nil {
+	if err := driver.Get(testpage); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/launcher/proxy/driverhub/screenshot/BUILD
+++ b/go/launcher/proxy/driverhub/screenshot/BUILD
@@ -41,18 +41,19 @@ web_test_config(
 go_web_test_suite(
     name = "screenshot_test",
     srcs = ["screenshot_test.go"],
-    browsers = ["//browsers:chromium-native"],
+    browsers = ["//browsers/sauce:chrome55-win10"],
     config = ":screenshot_test_config",
-    data = ["//go/launcher/proxy/testdata:testpage.html"],
+    data = ["//go/launcher/proxy/testdata"],
     go_test_tags = [
         "manual",
         "noci",
     ],
     library = ":go_default_library",
     local = True,
-    tags = ["noci"],
+    tags = ["requires-network"],
     deps = [
         "//go/bazel:go_default_library",
+        "//go/portpicker:go_default_library",
         "//go/webtest:go_default_library",
         "@com_github_tebeka_selenium//:go_default_library",
     ],

--- a/go/launcher/proxy/driverhub/screenshot/screenshot_test.go
+++ b/go/launcher/proxy/driverhub/screenshot/screenshot_test.go
@@ -15,23 +15,46 @@
 package screenshot
 
 import (
+	"fmt"
 	"image/png"
 	"io/ioutil"
+	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/bazelbuild/rules_webtesting/go/bazel"
+	"github.com/bazelbuild/rules_webtesting/go/portpicker"
 	"github.com/bazelbuild/rules_webtesting/go/webtest"
 	"github.com/tebeka/selenium"
 )
 
-func TestScreenshot(t *testing.T) {
-	testpage, err := bazel.Runfile("go/launcher/proxy/testdata/testpage.html")
+var testpage = ""
+
+func TestMain(m *testing.M) {
+	port, err := portpicker.PickUnusedPort()
 	if err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
 
+	dir, err := bazel.RunfilesPath()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dir = filepath.Join(dir, bazel.TestWorkspace())
+
+	go func() {
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), http.FileServer(http.Dir(dir))))
+	}()
+
+	testpage = fmt.Sprintf("http://localhost:%d/go/launcher/proxy/testdata/testpage.html", port)
+
+	os.Exit(m.Run())
+}
+
+func TestScreenshot(t *testing.T) {
 	driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +62,7 @@ func TestScreenshot(t *testing.T) {
 
 	defer driver.Quit()
 
-	if err := driver.Get("file://" + testpage); err != nil {
+	if err := driver.Get(testpage); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/launcher/proxy/testdata/BUILD
+++ b/go/launcher/proxy/testdata/BUILD
@@ -18,7 +18,8 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
-exports_files(
-    glob(["**"]),
+filegroup(
+    name = "testdata",
+    srcs = glob(["*"]),
     visibility = ["//go:__subpackages__"],
 )

--- a/go/launcher/webdriver/BUILD
+++ b/go/launcher/webdriver/BUILD
@@ -37,15 +37,12 @@ go_library(
 go_web_test_suite(
     name = "webdriver_test",
     srcs = ["webdriver_test.go"],
-    browsers = [
-        "//browsers:chromium-native",
-        "//browsers:firefox-native",
-    ],
+    browsers = ["//browsers/sauce:chrome55-win10"],
     go_test_tags = [
         "manual",
         "noci",
     ],
     library = ":go_default_library",
     local = True,
-    tags = ["noci"],
+    tags = ["requires-network"],
 )

--- a/go/launcher/webdriver/webdriver_test.go
+++ b/go/launcher/webdriver/webdriver_test.go
@@ -33,23 +33,6 @@ func TestCreateSessionAndQuit(t *testing.T) {
 	}
 }
 
-func TestCreateSessionFails(t *testing.T) {
-	ctx := context.Background()
-
-	d, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{
-		"chromeOptions": map[string]interface{}{
-			"binary": "a-binary",
-		},
-		"moz:firefoxOptions": map[string]interface{}{
-			"binary": "a-binary",
-		},
-	})
-	if err == nil {
-		t.Error("got nil err from CreateSession with bad capabilities")
-		d.Quit(ctx)
-	}
-}
-
 func TestHealthy(t *testing.T) {
 	ctx := context.Background()
 

--- a/go/metadata/BUILD
+++ b/go/metadata/BUILD
@@ -39,14 +39,7 @@ go_test(
         "extension_test.go",
         "metadata_test.go",
     ],
-    data = [
-        "//go/metadata/testdata:all-fields.json",
-        "//go/metadata/testdata:android-browser-gingerbread-nexus-s.json",
-        "//go/metadata/testdata:bad-named-files.json",
-        "//go/metadata/testdata:chrome-linux.json",
-        "//go/metadata/testdata:extension.json",
-        "//go/metadata/testdata:merge-from-file-result.json",
-    ],
+    data = ["//go/metadata/testdata"],
     library = ":go_default_library",
     deps = ["//go/bazel:go_default_library"],
 )

--- a/go/metadata/testdata/BUILD
+++ b/go/metadata/testdata/BUILD
@@ -18,7 +18,8 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
-exports_files(
-    glob(["**"]),
+filegroup(
+    name = "testdata",
+    srcs = glob(["*"]),
     visibility = ["//go:__subpackages__"],
 )

--- a/go/screenshotter/BUILD
+++ b/go/screenshotter/BUILD
@@ -29,19 +29,20 @@ go_library(
 )
 
 go_web_test_suite(
-    name = "go_default_test",
+    name = "screenshotter_test",
     srcs = ["screenshotter_test.go"],
-    browsers = ["//browsers:chromium-native"],
-    data = ["//go/launcher/proxy/testdata:testpage.html"],
+    browsers = ["//browsers/sauce:chrome55-win10"],
+    data = ["//go/launcher/proxy/testdata"],
     go_test_tags = [
         "manual",
         "noci",
     ],
     library = ":go_default_library",
     local = True,
-    tags = ["noci"],
+    tags = ["requires-network"],
     deps = [
         "//go/bazel:go_default_library",
+        "//go/portpicker:go_default_library",        
         "//go/webtest:go_default_library",
         "@com_github_tebeka_selenium//:go_default_library",
     ],

--- a/go/webtest/BUILD
+++ b/go/webtest/BUILD
@@ -39,16 +39,16 @@ go_web_test_suite(
         "webtest_test.go",
     ],
     browser_overrides = {
-        "//browsers:chrome55-win10-sauce": {
+        "//browsers/sauce:chrome55-win10": {
             "tags": ["requires-network"],
         },
     },
     browsers = [
-        "//browsers:chrome55-win10-sauce",
+        "//browsers/sauce:chrome55-win10",
         "//browsers:chromium-native",
         "//browsers:firefox-native",
     ],
-    data = ["//go/metadata/testdata:all-fields.json"],
+    data = ["//go/metadata/testdata"],
     go_test_tags = [
         "manual",
         "noci",

--- a/javatests/com/google/testing/web/BUILD
+++ b/javatests/com/google/testing/web/BUILD
@@ -16,29 +16,20 @@
 #
 package(default_testonly = True)
 
-load("//web:java.bzl", "java_web_test_suite")
-
 licenses(["notice"])  # Apache 2.0
+
+load("//web:java.bzl", "java_web_test_suite")
 
 java_web_test_suite(
     name = "WebTestTest",
     srcs = ["WebTestTest.java"],
-    browser_overrides = {
-        "//browsers:chrome55-win10-sauce": {
-            "tags": ["requires-network"],
-        },
-    },
-    browsers = [
-        "//browsers:chrome55-win10-sauce",
-        "//browsers:chromium-native",
-        "//browsers:firefox-native",
-    ],
+    browsers = ["//browsers/sauce:chrome55-win10"],
     java_test_tags = [
         "manual",
         "noci",
     ],
     local = True,
-    tags = ["noci"],
+    tags = ["requires-network"],
     deps = [
         "//java/com/google/testing/web",
         "@junit",

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -16,9 +16,9 @@
 #
 package(default_testonly = True)
 
-load("//web:py.bzl", "py_web_test_suite")
-
 licenses(["notice"])  # Apache 2.0
+
+load("//web:py.bzl", "py_web_test_suite")
 
 py_library(
     name = "web",
@@ -34,22 +34,13 @@ py_library(
 py_web_test_suite(
     name = "webtest_test",
     srcs = ["webtest_test.py"],
-    browser_overrides = {
-        "//browsers:chrome55-win10-sauce": {
-            "tags": ["requires-network"],
-        },
-    },
-    browsers = [
-        "//browsers:chrome55-win10-sauce",
-        "//browsers:chromium-native",
-        "//browsers:firefox-native",
-    ],
+    browsers = ["//browsers/sauce:chrome55-win10"],
     local = True,
     py_test_tags = [
         "manual",
         "noci",
     ],
     srcs_version = "PY2AND3",
-    tags = ["noci"],
+    tags = ["requires-network"],
     deps = [":web"],
 )

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,6 +2,7 @@
 test --test_env=DISPLAY
 
 # For running sauce-based configs.
-test --test_env=SAUCE_USERNAME=bazel_rules_webtesting
-test --test_env=SAUCE_ACCESS_KEY=c5bed09c-a8a6-44c8-af02-a545905f957f
+test --test_env=SAUCE_USERNAME
+test --test_env=SAUCE_ACCESS_KEY
 test --test_env=TUNNEL_IDENTIFIER
+test --test_env=BUILD_TAG

--- a/web/internal/metadata.bzl
+++ b/web/internal/metadata.bzl
@@ -44,7 +44,9 @@ def _create_file(ctx,
                  output,
                  browser_label=None,
                  capabilities=None,
+                 config_label=None,
                  environment=None,
+                 label=None,
                  test_label=None,
                  web_test_files=None,
                  extension=None):
@@ -62,13 +64,16 @@ def _create_file(ctx,
       metadata file.
   """
   fields = {}
-
-  if capabilities:
-    fields["capabilities"] = capabilities
-  if environment:
-    fields["environment"] = environment
   if browser_label:
     fields["browserLabel"] = str(browser_label)
+  if capabilities:
+    fields["capabilities"] = capabilities
+  if config_label:
+    fields["configLabel"] = str(config_label)
+  if environment:
+    fields["environment"] = environment
+  if label:
+    fields["label"] = str(label)
   if test_label:
     fields["testLabel"] = str(test_label)
   if web_test_files:

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -86,7 +86,12 @@ def _generate_noop_test(ctx, reason, status=0):
 
 def _generate_default_test(ctx):
   patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
-  metadata.create_file(ctx=ctx, output=patch, test_label=ctx.attr.test.label)
+  metadata.create_file(
+      ctx=ctx,
+      output=patch,
+      config_label=ctx.attr.config.label,
+      label=ctx.label,
+      test_label=ctx.attr.test.label)
 
   metadata.merge_files(
       ctx=ctx,


### PR DESCRIPTION
- Move SauceLabs browsers into subdirectory.
- Properly name and tag sauce lab browsers.
- Add support for referencing label, testLabel, browserLabel,
configLabel, and environment fields of metadata in capabilities.