### PR TITLE
Export annotations from Guava

### DIFF
--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -212,7 +212,7 @@ def com_google_guava():
       ],
       jar_sha256="36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
       licenses=["notice"],  # Apache 2.0
-      deps=[
+      exports=[
           "@com_google_code_findbugs_jsr305",
           "@com_google_errorprone_error_prone_annotations",
       ])


### PR DESCRIPTION
These annotations are part of guava's API, and they cannot safely be optimized off the compile-time classpath. This works around google/error-prone#615. See also bazelbuild/rules_closure@accdcb0b6be2783cd2b82e646c6180bb21361741

**Note:** I must apologize on behalf of GitHub's GUI for creating this branch in your repository, rather than my fork.