### PR TITLE
Use FQDN in exported addresses.

### DIFF
--- a/go/httphelper/BUILD
+++ b/go/httphelper/BUILD
@@ -18,10 +18,16 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["http_helper.go"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["http_helper_test.go"],
+    library = ":go_default_library",
 )

--- a/go/httphelper/http_helper.go
+++ b/go/httphelper/http_helper.go
@@ -19,8 +19,10 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -97,4 +99,29 @@ func constructURL(base, path, prefix string) (*url.URL, error) {
 	}
 
 	return u.ResolveReference(ref), err
+}
+
+func FQDN() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	addrs, err := net.LookupHost(hostname)
+	if err != nil {
+		return hostname, nil
+	}
+
+	for _, addr := range addrs {
+		if names, err := net.LookupAddr(addr); err != nil && len(names) >= 0 {
+			for _, name := range names {
+				if strings.HasPrefix(name, hostname) {
+					return name, nil
+				}
+			}
+			return names[0], nil
+		}
+	}
+
+	return hostname, nil
 }

--- a/go/httphelper/http_helper_test.go
+++ b/go/httphelper/http_helper_test.go
@@ -1,0 +1,21 @@
+package httphelper
+
+import (
+  "os"
+  "strings"
+  "testing"
+)
+
+func TestFQDN(t *testing.T) {
+  fqdn, err := FQDN()
+
+  if err != nil {
+    t.Error(err)
+  }
+
+  name, _ := os.Hostname()
+
+  if !strings.HasPrefix(fqdn, name) {
+    t.Errorf("Got %q, expected to start with %q", fqdn, name)
+  }
+}

--- a/go/launcher/proxy/driverhub/driver_hub.go
+++ b/go/launcher/proxy/driverhub/driver_hub.go
@@ -45,6 +45,7 @@ type WebDriverHub struct {
 	*metadata.Metadata
 	*http.Client
 	diagnostics.Diagnostics
+	Proxy proxy.Proxy
 
 	healthyOnce sync.Once
 
@@ -63,6 +64,7 @@ func HTTPHandlerProvider(p *proxy.Proxy) (proxy.HTTPHandler, error) {
 		Client:      &http.Client{},
 		Diagnostics: p.Diagnostics,
 		Metadata:    p.Metadata,
+		Proxy:       p,
 	}
 
 	h.Path("/wd/hub/session").Methods("POST").HandlerFunc(h.createSession)

--- a/go/launcher/proxy/proxy.go
+++ b/go/launcher/proxy/proxy.go
@@ -75,11 +75,17 @@ func New(env environment.Env, m *metadata.Metadata, d diagnostics.Diagnostics) (
 	if err != nil {
 		return nil, errors.New(compName, err)
 	}
+
+	fqdn, err := httphelper.FQDN()
+	if err != nil {
+		return nil, errors.New(compName, err)
+	}
+
 	p := &Proxy{
 		Diagnostics: d,
 		Env:         env,
 		Metadata:    m,
-		Address:     net.JoinHostPort("localhost", strconv.Itoa(port)),
+		Address:     net.JoinHostPort(fqdn, strconv.Itoa(port)),
 		port:        port,
 	}
 


### PR DESCRIPTION
- Make proxy address available from WebDriverHub.