### PR TITLE
Add ExecuteScriptAsyncWithTimeout to webdriver.

### DIFF
--- a/go/launcher/main/BUILD
+++ b/go/launcher/main/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//go/launcher/proxy/driverhub/googlescreenshot:go_default_library",
         "//go/launcher/proxy/driverhub/mobileemulation:go_default_library",
         "//go/launcher/proxy/driverhub/quithandler:go_default_library",
+        "//go/launcher/proxy/driverhub/scripttimeout:go_default_library",
         "//go/launcher/proxy/healthz:go_default_library",
         "//go/metadata:go_default_library",
     ],

--- a/go/launcher/main/config.go
+++ b/go/launcher/main/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub/googlescreenshot"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub/mobileemulation"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub/quithandler"
+	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub/scripttimeout"
 	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy/healthz"
 )
 
@@ -41,5 +42,6 @@ func init() {
 	// Configure WebDriver handlers.
 	driverhub.HandlerProviderFunc(mobileemulation.ProviderFunc)
 	driverhub.HandlerProviderFunc(quithandler.ProviderFunc)
+	driverhub.HandlerProviderFunc(scripttimeout.ProviderFunc)
 	driverhub.HandlerProviderFunc(googlescreenshot.ProviderFunc)
 }

--- a/go/launcher/proxy/driverhub/scripttimeout/BUILD
+++ b/go/launcher/proxy/driverhub/scripttimeout/BUILD
@@ -1,0 +1,49 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+package(default_testonly = True)
+
+licenses(["notice"])  # Apache 2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//web:go.bzl", "go_web_test_suite")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["script_timeout.go"],
+    visibility = ["//visibility:public"],
+    deps = ["//go/launcher/proxy/driverhub:go_default_library"],
+)
+
+go_web_test_suite(
+    name = "script_timeout_test",
+    srcs = ["script_timeout_test.go"],
+    browsers = ["//browsers/sauce:chrome55-win10"],
+    data = ["//go/launcher/proxy/testdata"],
+    go_test_tags = [
+        "manual",
+        "noci",
+    ],
+    library = ":go_default_library",
+    local = True,
+    tags = ["requires-network"],
+    deps = [
+        "//go/bazel:go_default_library",
+        "//go/portpicker:go_default_library",
+        "//go/webtest:go_default_library",
+        "@com_github_tebeka_selenium//:go_default_library",
+    ],
+)

--- a/go/launcher/proxy/driverhub/scripttimeout/script_timeout.go
+++ b/go/launcher/proxy/driverhub/scripttimeout/script_timeout.go
@@ -48,6 +48,22 @@ func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interf
         }
       }
 
+      if t, ok := request["type"].(string); ok && t == "script" {
+        if timeout, ok := request["ms"].(int); ok {
+          if err := session.WebDriver.SetScriptTimeout(ctx, time.Duration(timeout)*time.Millisecond); err == nil {
+            delete(request, "ms")
+            delete(request, "type")
+          }
+        }
+
+        if timeout, ok := request["ms"].(float64); ok {
+          if err := session.WebDriver.SetScriptTimeout(ctx, time.Duration(timeout)*time.Millisecond); err == nil {
+            delete(request, "ms")
+            delete(request, "type")
+          }
+        }
+      }
+
       if len(request) == 0 {
         return driverhub.Response{
           Status: http.StatusOK,

--- a/go/launcher/proxy/driverhub/scripttimeout/script_timeout.go
+++ b/go/launcher/proxy/driverhub/scripttimeout/script_timeout.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scripttimeout translates calls to set script timeout into calls
+// on the WebDriver object so it can record the last set script timeout.
+package scripttimeout
+
+import (
+  "context"
+  "encoding/json"
+  "net/http"
+  "time"
+
+  "github.com/bazelbuild/rules_webtesting/go/launcher/proxy/driverhub"
+)
+
+// ProviderFunc provides a handler for set script timeout commands.
+func ProviderFunc(session *driverhub.WebDriverSession, desired map[string]interface{}, base driverhub.HandlerFunc) (driverhub.HandlerFunc, bool) {
+  return func(ctx context.Context, rq driverhub.Request) (driverhub.Response, error) {
+
+    if rq.Method == http.MethodPost && len(rq.Path) == 1 && rq.Path[0] == "timeouts" {
+      var request map[string]interface{}
+
+      if err := json.Unmarshal(rq.Body, &request); err != nil {
+        return base(ctx, rq)
+      }
+
+      if timeout, ok := request["script"].(int); ok {
+        if err := session.WebDriver.SetScriptTimeout(ctx, time.Duration(timeout)*time.Millisecond); err == nil {
+          delete(request, "script")
+        }
+      }
+
+      if timeout, ok := request["script"].(float64); ok {
+        if err := session.WebDriver.SetScriptTimeout(ctx, time.Duration(timeout)*time.Millisecond); err == nil {
+          delete(request, "script")
+        }
+      }
+
+      if len(request) == 0 {
+        return driverhub.Response{
+          Status: http.StatusOK,
+          Body:   []byte(`{"status": 0}`),
+        }, nil
+      }
+
+      body, err := json.Marshal(request)
+      if err == nil {
+        rq.Body = body
+      }
+    }
+
+    if rq.Method == http.MethodPost && len(rq.Path) == 2 && rq.Path[0] == "timeouts" && rq.Path[1] == "async_script" {
+      var request map[string]interface{}
+
+      if err := json.Unmarshal(rq.Body, &request); err != nil {
+        return base(ctx, rq)
+      }
+
+      if timeout, ok := request["ms"].(int); ok {
+        if err := session.WebDriver.SetScriptTimeout(ctx, time.Duration(timeout)*time.Millisecond); err == nil {
+          return driverhub.Response{
+            Status: http.StatusOK,
+            Body:   []byte(`{"status": 0}`),
+          }, nil
+        }
+      }
+
+      if timeout, ok := request["ms"].(float64); ok {
+        if err := session.WebDriver.SetScriptTimeout(ctx, time.Duration(timeout)*time.Millisecond); err == nil {
+          return driverhub.Response{
+            Status: http.StatusOK,
+            Body:   []byte(`{"status": 0}`),
+          }, nil
+        }
+      }
+    }
+
+    return base(ctx, rq)
+  }, true
+}

--- a/go/launcher/proxy/driverhub/scripttimeout/script_timeout_test.go
+++ b/go/launcher/proxy/driverhub/scripttimeout/script_timeout_test.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scripttimeout
+
+import (
+  "fmt"
+  "log"
+  "net/http"
+  "os"
+  "path/filepath"
+  "testing"
+  "time"
+
+  "github.com/bazelbuild/rules_webtesting/go/bazel"
+  "github.com/bazelbuild/rules_webtesting/go/portpicker"
+  "github.com/bazelbuild/rules_webtesting/go/webtest"
+  "github.com/tebeka/selenium"
+)
+
+var testpage = ""
+
+func TestMain(m *testing.M) {
+  port, err := portpicker.PickUnusedPort()
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  dir, err := bazel.RunfilesPath()
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  dir = filepath.Join(dir, bazel.TestWorkspace())
+
+  go func() {
+    log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), http.FileServer(http.Dir(dir))))
+  }()
+
+  testpage = fmt.Sprintf("http://localhost:%d/go/launcher/proxy/testdata/testpage.html", port)
+
+  os.Exit(m.Run())
+}
+
+func TestSetScriptTimeout(t *testing.T) {
+  // This test only superficially tests script timeout functionality (e.g. that the timeout still gets set).
+  driver, err := webtest.NewWebDriverSession(selenium.Capabilities{})
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  defer driver.Quit()
+
+  if err := driver.Get(testpage); err != nil {
+    t.Fatal(err)
+  }
+
+  if err := driver.SetAsyncScriptTimeout(1 * time.Second); err != nil {
+    t.Fatal(err)
+  }
+
+  start := time.Now()
+  if _, err := driver.ExecuteScriptAsync("return;", []interface{}{}); err == nil {
+    t.Fatal("got nil err, expected timeout err")
+  }
+  if run := time.Now().Sub(start); run < 1*time.Second {
+    t.Fatal("got runtime %v, expected to be at least 1 seconds", run)
+  }
+
+  if err := driver.SetAsyncScriptTimeout(5 * time.Second); err != nil {
+    t.Fatal(err)
+  }
+
+  start = time.Now()
+  if _, err := driver.ExecuteScriptAsync("return;", []interface{}{}); err == nil {
+    t.Fatal("got nil err, expected timeout err")
+  }
+  if run := time.Now().Sub(start); run < 5*time.Second {
+    t.Fatal("got runtime %v, expected to be at least 1 seconds", run)
+  }
+
+}


### PR DESCRIPTION
This allows driverhub handlers to implement features with
execute script async commands that set their own timeouts
but then restore the original timeout so as not affect other
commands.