### PR TITLE
Fix FQDN.

### DIFF
--- a/go/httphelper/http_helper.go
+++ b/go/httphelper/http_helper.go
@@ -101,6 +101,20 @@ func constructURL(base, path, prefix string) (*url.URL, error) {
 	return u.ResolveReference(ref), err
 }
 
+type longestToShortest []string
+
+func (s longestToShortest) Len() int {
+    return len(s)
+}
+
+func (s longestToShortest) Swap(i, j int) {
+    s[i], s[j] = s[j], s[i]
+}
+
+func (s longestToShortest) Less(i, j int) bool {
+    return len(s[i]) > len(s[j])
+}
+
 // FQDN returns the fully-qualified domain name (or os.Hostname if lookup fails).
 func FQDN() (string, error) {
 	hostname, err := os.Hostname()
@@ -114,8 +128,10 @@ func FQDN() (string, error) {
 	}
 
 	for _, addr := range addrs {
-		if names, err := net.LookupAddr(addr); err != nil && len(names) >= 0 {
+		if names, err := net.LookupAddr(addr); err == nil && len(names) > 0 {
+			sort.Sort(longestToShortest(names))
 			for _, name := range names {
+				name = strings.TrimRight(name, ".")
 				if strings.HasPrefix(name, hostname) {
 					return name, nil
 				}

--- a/go/httphelper/http_helper.go
+++ b/go/httphelper/http_helper.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 )
 


### PR DESCRIPTION
Fix FQDN.

1. The names loop was being skipped; it should be executed when there is no err.
2. The fully qualified domain name returned by net.LookupAddr may have a trailing period which is not required and should be stripped so that it looks more like what a user would expect; for example, return "x.y.com" rather than "x.y.com.".
3. Sort the names longest to shortest. The list of names may contain a non-FQDN; make this method resilient to the order of names returned by net.LookupAddr.