### PR TITLE
Fix testonly and cfgs.

### DIFF
--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -59,7 +59,7 @@ browser = rule(
                 cfg="host",
                 default=Label("//go/metadata/main")),
         "metadata":
-            attr.label(mandatory=True, allow_single_file=[".json"], cfg="data"),
+            attr.label(mandatory=True, allow_single_file=[".json"]),
         "required_tags":
             attr.string_list(),
     },
@@ -72,10 +72,10 @@ Args:
   deps: Other web_test-related rules that this rule depends on.
   disabled: If set, then a no-op test will be run for all tests using
     this browser.
-  environment: Map of environment variables-values to set for this browser.  
-  merger: Metadata merger executable.  
+  environment: Map of environment variables-values to set for this browser.
+  merger: Metadata merger executable.
   metadata: The web_test metadata file that defines how this browser
-    is launched and default capabilities for this browser.  
+    is launched and default capabilities for this browser.
   required_tags: A list of tags that all web_tests using this browser
     should have. Examples include "requires-network", "local", etc.
 """

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -133,13 +133,13 @@ def _generate_default_test(ctx):
 web_test = rule(
     attrs={
         "browser":
-            attr.label(cfg="data", mandatory=True, providers=["web_test"]),
+            attr.label(mandatory=True, providers=["web_test"]),
         "config":
-            attr.label(cfg="data", mandatory=True, providers=["web_test"]),
+            attr.label(mandatory=True, providers=["web_test"]),
         "data":
             attr.label_list(allow_files=True, cfg="data"),
         "launcher":
-            attr.label(cfg="data", executable=True),
+            attr.label(cfg="target", executable=True),
         "merger":
             attr.label(
                 cfg="host",
@@ -150,7 +150,7 @@ web_test = rule(
                 allow_single_file=True,
                 default=Label("//web/internal:noop_web_test.sh.template")),
         "test":
-            attr.label(cfg="data", executable=True, mandatory=True),
+            attr.label(cfg="target", executable=True, mandatory=True),
         "web_test_template":
             attr.label(
                 allow_single_file=True,

--- a/web/internal/web_test_archive.bzl
+++ b/web/internal/web_test_archive.bzl
@@ -59,7 +59,6 @@ web_test_archive = rule(
                     ".tar.Z",
                     ".zip",
                 ],
-                cfg="data",
                 mandatory=True),
         "data":
             attr.label_list(allow_files=True, cfg="data"),

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -56,7 +56,8 @@ web_test_named_executable = rule(
             attr.label_list(providers=["web_test"]),
         "executable":
             attr.label(
-                allow_files=True, executable=True, cfg="data", mandatory=True),
+                allow_files=True, executable=True, cfg="target",
+                mandatory=True),
         "merger":
             attr.label(
                 executable=True,

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -51,7 +51,7 @@ web_test_named_file = rule(
         "deps":
             attr.label_list(providers=["web_test"]),
         "file":
-            attr.label(allow_single_file=True, cfg="data", mandatory=True),
+            attr.label(allow_single_file=True, mandatory=True),
         "merger":
             attr.label(
                 executable=True,

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -107,11 +107,9 @@ def _apply_browser_overrides(kwargs, overrides):
   return overridden_kwargs
 
 
-def browser(testonly=True, **kwargs):
+def browser(**kwargs):
   """Wrapper around browser to correctly set defaults."""
-  if testonly == None:
-    testonly = True
-  browser_alias(testonly=testonly, **kwargs)
+  browser_alias(testonly=True, **kwargs)
 
 
 def web_test(
@@ -138,32 +136,24 @@ def web_test(
       **kwargs)
 
 
-def web_test_config(testonly=True, **kwargs):
+def web_test_config(**kwargs):
   """Wrapper around web_test_config to correctly set defaults."""
-  if testonly == None:
-    testonly = True
-  web_test_config_alias(testonly=testonly, **kwargs)
+  web_test_config_alias(testonly=True, **kwargs)
 
 
-def web_test_named_executable(executable, data=None, testonly=True, **kwargs):
+def web_test_named_executable(executable, data=None, **kwargs):
   """Wrapper around web_test_named_executable to correctly set defaults."""
   data = lists.clone(data)
   lists.ensure_contains(data, executable)
-  if testonly == None:
-    testonly = True
   web_test_named_executable_alias(
-      data=data, executable=executable, testonly=testonly, **kwargs)
+      data=data, executable=executable, testonly=True, **kwargs)
 
 
-def web_test_named_file(testonly=True, **kwargs):
+def web_test_named_file(data**kwargs):
   """Wrapper around web_test_named_file to correctly set defaults."""
-  if testonly == None:
-    testonly = True
-  web_test_named_file_alias(testonly=testonly, **kwargs)
+  web_test_named_file_alias(testonly=True, **kwargs)
 
 
-def web_test_archive(testonly=True, **kwargs):
+def web_test_archive(**kwargs):
   """Wrapper around web_test_archive to correctly set defaults."""
-  if testonly == None:
-    testonly = True
-  web_test_archive_alias(testonly=testonly, **kwargs)
+  web_test_archive_alias(testonly=True, **kwargs)

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -149,7 +149,7 @@ def web_test_named_executable(executable, data=None, **kwargs):
       data=data, executable=executable, testonly=True, **kwargs)
 
 
-def web_test_named_file(data**kwargs):
+def web_test_named_file(**kwargs):
   """Wrapper around web_test_named_file to correctly set defaults."""
   web_test_named_file_alias(testonly=True, **kwargs)
 


### PR DESCRIPTION
- All web_test_* rules must be testonly as they depend on
  metadata merger which is testonly.
- Executables used at runtime should be build in cfg="target".
- cfg="data" should only be used for data attributes.