### PR TITLE
Support parsing W3C New Session requests.

### DIFF
--- a/go/launcher/environment/environment.go
+++ b/go/launcher/environment/environment.go
@@ -41,7 +41,7 @@ type Env interface {
 	// caps is the capabilities sent to the proxy from the client, and
 	// the return value is the capabilities that should be actually
 	// sent to the WebDriver server new session command.
-	StartSession(ctx context.Context, id int, caps map[string]interface{}) (map[string]interface{}, error)
+	StartSession(ctx context.Context, id int, caps capabilities.Spec) (capabilities.Spec, error)
 	// StartSession is called for each new WebDriver session, before
 	// the delete session command is sent to the WebDriver server.
 	StopSession(ctx context.Context, id int) error
@@ -86,15 +86,15 @@ func (b *Base) SetUp(ctx context.Context) error {
 // StartSession merges the passed in caps with b.Metadata.caps and returns the merged
 // capabilities that should be used when calling new session on the WebDriver
 // server.
-func (b *Base) StartSession(ctx context.Context, id int, caps map[string]interface{}) (map[string]interface{}, error) {
+func (b *Base) StartSession(ctx context.Context, id int, caps capabilities.Spec) (capabilities.Spec, error) {
 	if err := b.Healthy(ctx); err != nil {
-		return nil, err
+		return capabilities.Spec{}, err
 	}
 	resolved, err := b.Metadata.ResolvedCapabilities()
 	if err != nil {
-		return nil, err
+		return capabilities.Spec{}, err
 	}
-	updated := capabilities.Merge(resolved, caps)
+	updated := capabilities.MergeSpecOntoCaps(resolved, caps)
 	return updated, nil
 }
 

--- a/go/launcher/webdriver/BUILD
+++ b/go/launcher/webdriver/BUILD
@@ -31,6 +31,7 @@ go_library(
     deps = [
         "//go/launcher/errors:go_default_library",
         "//go/launcher/healthreporter:go_default_library",
+        "//go/metadata/capabilities:go_default_library",
     ],
 )
 

--- a/go/launcher/webdriver/webdriver_test.go
+++ b/go/launcher/webdriver/webdriver_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bazelbuild/rules_webtesting/go/metadata/capabilities"
 	"github.com/bazelbuild/rules_webtesting/go/webtest"
 )
 
 func TestCreateSessionAndQuit(t *testing.T) {
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestCreateSessionAndQuit(t *testing.T) {
 func TestHealthy(t *testing.T) {
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 1, nil)
+	d, err := CreateSession(ctx, wdAddress(), 1, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +97,7 @@ func TestExecuteScript(t *testing.T) {
 
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 1, nil)
+	d, err := CreateSession(ctx, wdAddress(), 1, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +161,7 @@ func TestExecuteScriptAsync(t *testing.T) {
 
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 1, nil)
+	d, err := CreateSession(ctx, wdAddress(), 1, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +189,7 @@ func TestExecuteScriptAsync(t *testing.T) {
 func TestScreenshot(t *testing.T) {
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +207,7 @@ func TestScreenshot(t *testing.T) {
 func TestWindowHandles(t *testing.T) {
 	ctx := context.Background()
 
-	driver, err := CreateSession(ctx, wdAddress(), 3, nil)
+	driver, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +223,7 @@ func TestWindowHandles(t *testing.T) {
 func TestQuit(t *testing.T) {
 	ctx := context.Background()
 
-	driver, err := CreateSession(ctx, wdAddress(), 3, nil)
+	driver, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +237,7 @@ func TestQuit(t *testing.T) {
 func TestExecuteScriptAsyncWithTimeout(t *testing.T) {
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,9 +267,11 @@ func TestExecuteScriptAsyncWithTimeout(t *testing.T) {
 func TestExecuteScriptAsyncWithTimeoutWithCaps(t *testing.T) {
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, map[string]interface{}{
-		"timeouts": map[string]interface{}{
-			"script": 5000,
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{
+		OSSCaps: map[string]interface{}{
+			"timeouts": map[string]interface{}{
+				"script": 5000,
+			},
 		},
 	})
 	if err != nil {
@@ -300,7 +303,7 @@ func TestGetWindowRect(t *testing.T) {
 
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +370,7 @@ func TestSetWindowRect(t *testing.T) {
 
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -431,7 +434,7 @@ func TestSetWindowSize(t *testing.T) {
 
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +516,7 @@ func TestSetWindowPosition(t *testing.T) {
 
 	ctx := context.Background()
 
-	d, err := CreateSession(ctx, wdAddress(), 3, nil)
+	d, err := CreateSession(ctx, wdAddress(), 3, capabilities.Spec{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/metadata/metadata.go
+++ b/go/metadata/metadata.go
@@ -165,12 +165,19 @@ func (m *Metadata) ToFile(filename string) error {
 
 // Equals compares two Metadata object and return true iff they are the same.
 func Equals(e, a *Metadata) bool {
+	var extsEqual bool
+	if e.Extension == nil {
+		extsEqual = (a.Extension == nil)
+	} else {
+		extsEqual = e.Extension.Equals(a.Extension)
+	}
 	// TODO(DrMarcII): should consider equality of WebTestFiles.
-	return capabilities.Equals(e.Capabilities, a.Capabilities) &&
+	return capabilities.JSONEquals(e.Capabilities, a.Capabilities) &&
 		e.Environment == a.Environment &&
 		e.BrowserLabel == a.BrowserLabel &&
 		e.TestLabel == a.TestLabel &&
-		webTestFilesSliceEquals(e.WebTestFiles, a.WebTestFiles)
+		webTestFilesSliceEquals(e.WebTestFiles, a.WebTestFiles) &&
+		extsEqual
 }
 
 func mapEquals(e, a map[string]string) bool {
@@ -304,7 +311,7 @@ func (e *extension) Equals(other Extension) bool {
 	if !ok {
 		return false
 	}
-	return capabilities.Equals(e.value, o.value)
+	return capabilities.JSONEquals(e.value, o.value)
 }
 
 func (e *extension) UnmarshalJSON(b []byte) error {

--- a/go/metadata/metadata_test.go
+++ b/go/metadata/metadata_test.go
@@ -40,9 +40,11 @@ func TestFromFile(t *testing.T) {
 		}
 
 		expected := &Metadata{
+			Capabilities: map[string]interface{}{},
 			Environment:  "chromeos",
 			BrowserLabel: "//browsers:figaro",
 			TestLabel:    "//go/launcher:tests",
+			Extension:    &extension{},
 		}
 
 		if !Equals(expected, file) {

--- a/go/webtest/webtest_test.go
+++ b/go/webtest/webtest_test.go
@@ -46,8 +46,8 @@ func TestProvisionBrowser_NoCaps(t *testing.T) {
 
 func TestProvisionBrowser_WithCaps(t *testing.T) {
 	wd, err := NewWebDriverSession(selenium.Capabilities{
-		"unexpectedAlertBehaviour": "dismiss",
-		"elementScrollBehavior":    1,
+		"acceptInsecureCerts": false,
+		"pageLoadStrategy":    "normal",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/testing/web/webtest_test.py
+++ b/testing/web/webtest_test.py
@@ -30,8 +30,8 @@ class BrowserTest(unittest.TestCase):
 
   def testBrowserProvisioningWithCaps(self):
     capabilities = {
-        "unexpectedAlertBehaviour": "dismiss",
-        "elementScrollBehavior": 1,
+        "acceptInsecureCerts": false,
+        "pageLoadStrategy": "normal",
     }
     driver = webtest.new_webdriver_session(capabilities)
 


### PR DESCRIPTION
New Session requests are treated as two sets of capabilities: the OSS set ("desiredCapabilities") and the W3C set ("alwaysMatch"). Only one set of capabilities is provided in browser metadata. When the capabilities from a New Session request are merged onto metadata capabilities, both sets of capabilities are updated.