### PR TITLE
Fix False keyword

### DIFF
--- a/testing/web/webtest_test.py
+++ b/testing/web/webtest_test.py
@@ -30,7 +30,7 @@ class BrowserTest(unittest.TestCase):
 
   def testBrowserProvisioningWithCaps(self):
     capabilities = {
-        "acceptInsecureCerts": false,
+        "acceptInsecureCerts": False,
         "pageLoadStrategy": "normal",
     }
     driver = webtest.new_webdriver_session(capabilities)


### PR DESCRIPTION
Fix False keyword; Fixes #143

This change is to address CI failure: http://ci.bazel.io/job/rules_web/568/