### PR TITLE
fix some build errors with latest rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,11 +18,11 @@ workspace(name = "io_bazel_rules_webtesting")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "279f572eef887f020aececbd06eeb1856a28f1ce94f516ca56792b727f9fe5ba",
-    strip_prefix = "rules_go-a53e897771c8ab192771758b5e65286b93ecf4b6",
+    sha256 = "c5ae26c801c7c4a7e369d15c7bd11b1ece164ca2fa3b3fc2612281dbf9e44210",
+    strip_prefix = "rules_go-072a319be76f2c20b10c5c8b6f8cb8f3508f8196",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/a53e897771c8ab192771758b5e65286b93ecf4b6.tar.gz",
-        "https://github.com/bazelbuild/rules_go/archive/a53e897771c8ab192771758b5e65286b93ecf4b6.tar.gz",
+        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/072a319be76f2c20b10c5c8b6f8cb8f3508f8196.tar.gz",
+        "https://github.com/bazelbuild/rules_go/archive/072a319be76f2c20b10c5c8b6f8cb8f3508f8196.tar.gz",
     ],
 )
 

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -149,20 +149,17 @@ def com_github_gorilla_mux():
       sha256="1a1b35782b0e38534b81d90bb86993fe830a7c1c3974a562554399f850ccdfcd",
       strip_prefix="mux-1.4.0",
       build_tags=["go1.9"],
-      tag="v1.4.0",  # TODO(DrMarcII) remove when no longer needed
-      url="https://github.com/gorilla/mux/archive/v1.4.0.tar.gz")
+      urls=["https://github.com/gorilla/mux/archive/v1.4.0.tar.gz"])
 
 
 def com_github_tebeka_selenium():
   go_repository(
       name="com_github_tebeka_selenium",
-      # TODO(DrMarcII) Remove when no longer needed
-      commit="8f4861d1f09c100da29ceec85424c3c96df15170",
       importpath="github.com/tebeka/selenium",
       sha256="345f204a3ece2469dcc82b59860dec095006e179b1c2ba3e9433b14c90dae167",
       strip_prefix="selenium-8f4861d1f09c100da29ceec85424c3c96df15170",
-      url=
-      "https://github.com/tebeka/selenium/archive/8f4861d1f09c100da29ceec85424c3c96df15170.tar.gz"
+      urls=
+      ["https://github.com/tebeka/selenium/archive/8f4861d1f09c100da29ceec85424c3c96df15170.tar.gz"]
   )
 
 


### PR DESCRIPTION
fix build errors with latest rules_go

Recent rules_go versions do not have a `url` parameter on `go_repository`, so
rules_webtesting, unfortunately, has to be changed.

There is also a new requirement that if a `urls` parameter is specified, than a
`tag` or `commit` parameter may not be. So, we fix up the gorilla/mux and 
selenium deps.

This patch also upgrades the rules_go external in this WORKSPACE to its current
HEAD.

This does not address the noci tag problem discussed in #147.

Updates #147