### PR TITLE
Increase the WD proxy timeout.

### DIFF
--- a/go/launcher/proxy/proxy.go
+++ b/go/launcher/proxy/proxy.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	compName = "WebDriver proxy"
-	timeout  = 1 * time.Second
+	timeout  = 3 * time.Second
 )
 
 var handlerProviders = map[string]HTTPHandlerProvider{}


### PR DESCRIPTION
It *should* come up within a couple hundred ms even in slow cases, but sometimes test machines are really heavily loaded.