### PR TITLE
Fix "context canceled" check.

### DIFF
--- a/go/launcher/proxy/driverhub/driver_session.go
+++ b/go/launcher/proxy/driverhub/driver_session.go
@@ -231,16 +231,16 @@ func (s *WebDriverSession) defaultHandler(w http.ResponseWriter, r *http.Request
 		Body:   body,
 	}
 	resp, err := s.handler(ctx, req)
-	if err == context.Canceled {
-		log.Printf("[%s] request %+v was canceled.", s.Name(), req)
-		return
-	}
-	if err == context.DeadlineExceeded {
-		s.Warning(errors.New(s.Name(), fmt.Errorf("request %+v exceeded deadline", req)))
-		timeout(w, r.URL.Path)
-		return
-	}
 	if err != nil {
+		if ctx.Err() == context.Canceled {
+			log.Printf("[%s] request %+v was canceled.", s.Name(), req)
+			return
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			s.Warning(errors.New(s.Name(), fmt.Errorf("request %+v exceeded deadline", req)))
+			timeout(w, r.URL.Path)
+			return
+		}
 		s.Severe(errors.New(s.Name(), err))
 		unknownError(w, err)
 		return


### PR DESCRIPTION
We should be checking the error reported by the context, not the error returned by the handler, because the handler may wrap the context's error with additional information.