### PR TITLE
Minor cleanups:

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,28 @@ WebDriver.
 Add the following to your WORKSPACE file:
 
 ```bzl
-git_repository(
+# Load rules_go at master for example purposes only. You should specify
+# a specific version in your project.
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.4",
+    strip_prefix = "rules_go-master",
+    urls = [
+        "https://github.com/bazelbuild/rules_go/archive/master.tar.gz",
+    ],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
 go_repositories()
 
-git_repository(
+# Load rules_webtesting at master for example purposes only. You should specify
+# a specific version in your project.
+http_archive(
     name = "io_bazel_rules_webtesting",
-    remote = "https://github.com/bazelbuild/rules_webtesting.git",
-    tag = "HEAD",
+    strip_prefix = "rules_webtesting-master",
+    urls = [
+        "https://github.com/bazelbuild/rules_webtesting/archive/master.tar.gz",
+    ],
 )
 
 load("@io_bazel_rules_webtesting//web:repositories.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,11 +18,11 @@ workspace(name = "io_bazel_rules_webtesting")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "c5ae26c801c7c4a7e369d15c7bd11b1ece164ca2fa3b3fc2612281dbf9e44210",
-    strip_prefix = "rules_go-072a319be76f2c20b10c5c8b6f8cb8f3508f8196",
+    sha256 = "2b1011eb81affe4344bc5b90636c66ea4edcc4dea69677981c759f3bd73a3953",
+    strip_prefix = "rules_go-0.5.1",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/072a319be76f2c20b10c5c8b6f8cb8f3508f8196.tar.gz",
-        "https://github.com/bazelbuild/rules_go/archive/072a319be76f2c20b10c5c8b6f8cb8f3508f8196.tar.gz",
+        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/0.5.1.tar.gz",
+        "https://github.com/bazelbuild/rules_go/archive/0.5.1.tar.gz",
     ],
 )
 

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -65,7 +65,7 @@ def web_test_repositories(
   if not omit_cglib_nodep:
     cglib_nodep()
   if not omit_com_github_gorilla_context:
-    com_github_gorilla_context();
+    com_github_gorilla_context()
   if not omit_com_github_gorilla_mux:
     com_github_gorilla_mux()
   if not omit_com_github_tebeka_selenium:
@@ -151,7 +151,6 @@ def com_github_gorilla_context():
       importpath="github.com/gorilla/context",
       sha256="12a849b4e9a08619233d4490a281aa2d34a69f9eaf85c2295f5357927e4d1763",
       strip_prefix="context-1.1",
-      build_tags=["go1.9"],
       urls=["https://github.com/gorilla/context/archive/v1.1.tar.gz"])
 
 
@@ -161,7 +160,6 @@ def com_github_gorilla_mux():
       importpath="github.com/gorilla/mux",
       sha256="1a1b35782b0e38534b81d90bb86993fe830a7c1c3974a562554399f850ccdfcd",
       strip_prefix="mux-1.4.0",
-      build_tags=["go1.9"],
       urls=["https://github.com/gorilla/mux/archive/v1.4.0.tar.gz"])
 
 
@@ -171,9 +169,9 @@ def com_github_tebeka_selenium():
       importpath="github.com/tebeka/selenium",
       sha256="345f204a3ece2469dcc82b59860dec095006e179b1c2ba3e9433b14c90dae167",
       strip_prefix="selenium-8f4861d1f09c100da29ceec85424c3c96df15170",
-      urls=
-      ["https://github.com/tebeka/selenium/archive/8f4861d1f09c100da29ceec85424c3c96df15170.tar.gz"]
-  )
+      urls=[
+          "https://github.com/tebeka/selenium/archive/8f4861d1f09c100da29ceec85424c3c96df15170.tar.gz"
+      ])
 
 
 def com_google_code_findbugs_jsr305():


### PR DESCRIPTION
 * Remove unneeded build_tags from go_repository rules.
 * Update rules_go version.
 * Update example WORKSPACE in README.