### PR TITLE
Implement initial version of WTL Debugger.

### DIFF
--- a/go/launcher/proxy/driverhub/debugger/BUILD
+++ b/go/launcher/proxy/driverhub/debugger/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,23 +22,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "driver_hub.go",
-        "driver_responses.go",
-        "driver_session.go",
-    ],
+    srcs = ["debugger.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "//go/httphelper:go_default_library",
-        "//go/launcher/diagnostics:go_default_library",
-        "//go/launcher/environment:go_default_library",
         "//go/launcher/errors:go_default_library",
-        "//go/launcher/healthreporter:go_default_library",
-        "//go/launcher/proxy:go_default_library",
-        "//go/launcher/proxy/driverhub/debugger:go_default_library",
-        "//go/launcher/webdriver:go_default_library",
-        "//go/metadata:go_default_library",
-        "//go/metadata/capabilities:go_default_library",
-        "@com_github_gorilla_mux//:go_default_library",
     ],
 )

--- a/go/launcher/proxy/driverhub/debugger/BUILD
+++ b/go/launcher/proxy/driverhub/debugger/BUILD
@@ -18,7 +18,7 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -27,4 +27,10 @@ go_library(
     deps = [
         "//go/launcher/errors:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["debugger_test.go"],
+    library = ":go_default_library",
 )

--- a/go/launcher/proxy/driverhub/debugger/debugger_test.go
+++ b/go/launcher/proxy/driverhub/debugger/debugger_test.go
@@ -1,0 +1,148 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugger
+
+import (
+  "net/http"
+  "net/url"
+  "testing"
+)
+
+func TestBreakpointMatches(t *testing.T) {
+  testCases := []struct {
+    name       string
+    breakpoint *breakpoint
+    request    *http.Request
+    matches    bool
+  }{
+    {
+      "empty breakpoint matches everything",
+      &breakpoint{},
+      &http.Request{},
+      true,
+    },
+    {
+      "matching method",
+      &breakpoint{
+        Methods: []string{"POST", "GET"},
+      },
+      &http.Request{
+        Method: "POST",
+      },
+      true,
+    },
+    {
+      "non-matching method",
+      &breakpoint{
+        Methods: []string{"POST", "GET"},
+      },
+      &http.Request{
+        Method: "DELETE",
+      },
+      false,
+    },
+    {
+      "matching path",
+      &breakpoint{
+        Path: "url",
+      },
+      &http.Request{
+        URL: &url.URL{
+          Path: "/wd/hub/session/abc/url",
+        },
+      },
+      true,
+    },
+    {
+      "non-matching path",
+      &breakpoint{
+        Path: "url",
+      },
+      &http.Request{
+        URL: &url.URL{
+          Path: "/wd/hub/session/abc/elements",
+        },
+      },
+      false,
+    },
+    {
+      "non-matching method and matching path",
+      &breakpoint{
+        Methods: []string{"POST", "GET"},
+        Path:    "url",
+      },
+      &http.Request{
+        Method: "DELETE",
+        URL: &url.URL{
+          Path: "/wd/hub/session/abc/url",
+        },
+      },
+      false,
+    },
+    {
+      "matching method and non-matching path",
+      &breakpoint{
+        Methods: []string{"POST", "GET"},
+        Path:    "url",
+      },
+      &http.Request{
+        Method: "POST",
+        URL: &url.URL{
+          Path: "/wd/hub/session/abc/elements",
+        },
+      },
+      false,
+    },
+    {
+      "non-matching method and matching path",
+      &breakpoint{
+        Methods: []string{"POST", "GET"},
+        Path:    "url",
+      },
+      &http.Request{
+        Method: "DELETE",
+        URL: &url.URL{
+          Path: "/wd/hub/session/abc/url",
+        },
+      },
+      false,
+    },
+    {
+      "non-matching method and path",
+      &breakpoint{
+        Methods: []string{"POST", "GET"},
+        Path:    "url",
+      },
+      &http.Request{
+        Method: "DELETE",
+        URL: &url.URL{
+          Path: "/wd/hub/session/abc/elements",
+        },
+      },
+      false,
+    },
+  }
+
+  for _, tc := range testCases {
+    t.Run(tc.name, func(t *testing.T) {
+      if err := tc.breakpoint.initialize(); err != nil {
+        t.Fatal(err)
+      }
+      if m := tc.breakpoint.matches(tc.request); m != tc.matches {
+        t.Fatalf("got %+v.matches(%+v) == %v, expected %v", tc.breakpoint, tc.request, m, tc.matches)
+      }
+    })
+  }
+}

--- a/go/launcher/proxy/healthz/healthz.go
+++ b/go/launcher/proxy/healthz/healthz.go
@@ -16,25 +16,33 @@
 package healthz
 
 import (
-	"context"
-	"io"
-	"net/http"
+  "context"
+  "io"
+  "net/http"
 
-	"github.com/bazelbuild/rules_webtesting/go/launcher/proxy"
+  "github.com/bazelbuild/rules_webtesting/go/launcher/proxy"
 )
 
 type healthz struct{}
 
 // HTTPHandlerProvider returns a HTTPHandlerProvider for handling healthz requests.
 func HTTPHandlerProvider(*proxy.Proxy) (proxy.HTTPHandler, error) {
-	return &healthz{}, nil
+  return &healthz{}, nil
 }
 
 func (h *healthz) Shutdown(context.Context) error {
-	return nil
+  return nil
 }
 
 func (h *healthz) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
-	io.WriteString(w, "ok")
+  w.Header().Set("Content-Type", "text/plain")
+  io.WriteString(w, "ok")
+}
+
+func (*healthz) Name() string {
+  return "healthz http handler"
+}
+
+func (*healthz) Healthy(context.Context) error {
+  return nil
 }

--- a/go/metadata/metadata.go
+++ b/go/metadata/metadata.go
@@ -46,6 +46,8 @@ type Metadata struct {
 	TestLabel string `json:"testLabel,omitempty"`
 	// Config label set in the web_test rule.
 	ConfigLabel string `json:"configLabel,omitempty"`
+	// Whether the WTL Debugger should be enabled.
+	DebuggerPort int `json:"debuggerPort,omitempty"`
 	// A list of WebTestFiles with named files in them.
 	WebTestFiles []*WebTestFiles `json:"webTestFiles,omitempty"`
 	// An object for any additional metadata fields on this object.
@@ -93,6 +95,11 @@ func Merge(m1, m2 *Metadata) (*Metadata, error) {
 		configLabel = m2.ConfigLabel
 	}
 
+	debuggerPort := m1.DebuggerPort
+	if m2.DebuggerPort != 0 {
+		debuggerPort = m2.DebuggerPort
+	}
+
 	webTestFiles := []*WebTestFiles{}
 	webTestFiles = append(webTestFiles, m1.WebTestFiles...)
 	webTestFiles = append(webTestFiles, m2.WebTestFiles...)
@@ -120,6 +127,7 @@ func Merge(m1, m2 *Metadata) (*Metadata, error) {
 		BrowserLabel: browserLabel,
 		TestLabel:    testLabel,
 		ConfigLabel:  configLabel,
+		DebuggerPort: debuggerPort,
 		WebTestFiles: webTestFiles,
 		Extension:    extension,
 	}, nil
@@ -174,8 +182,11 @@ func Equals(e, a *Metadata) bool {
 	// TODO(DrMarcII): should consider equality of WebTestFiles.
 	return capabilities.JSONEquals(e.Capabilities, a.Capabilities) &&
 		e.Environment == a.Environment &&
+		e.Label == a.Label &&
 		e.BrowserLabel == a.BrowserLabel &&
 		e.TestLabel == a.TestLabel &&
+		e.ConfigLabel == a.ConfigLabel &&
+		e.DebuggerPort == a.DebuggerPort &&
 		webTestFilesSliceEquals(e.WebTestFiles, a.WebTestFiles) &&
 		extsEqual
 }

--- a/go/metadata/metadata.go
+++ b/go/metadata/metadata.go
@@ -46,7 +46,7 @@ type Metadata struct {
 	TestLabel string `json:"testLabel,omitempty"`
 	// Config label set in the web_test rule.
 	ConfigLabel string `json:"configLabel,omitempty"`
-	// Whether the WTL Debugger should be enabled.
+	// Port to connect debugger to. If 0, debugger will not be started.
 	DebuggerPort int `json:"debuggerPort,omitempty"`
 	// A list of WebTestFiles with named files in them.
 	WebTestFiles []*WebTestFiles `json:"webTestFiles,omitempty"`

--- a/go/metadata/metadata_test.go
+++ b/go/metadata/metadata_test.go
@@ -100,6 +100,7 @@ func TestMergeFromFile(t *testing.T) {
 }
 
 func TestMerge(t *testing.T) {
+
 	testCases := []struct {
 		name   string
 		input1 *Metadata
@@ -141,6 +142,24 @@ func TestMerge(t *testing.T) {
 			&Metadata{TestLabel: "//browsers:figaro"},
 			&Metadata{TestLabel: ""},
 			&Metadata{TestLabel: "//browsers:figaro"},
+		},
+		{
+			"EnableDebugger, no override",
+			&Metadata{DebuggerPort: 1},
+			&Metadata{DebuggerPort: 0},
+			&Metadata{DebuggerPort: 1},
+		},
+		{
+			"EnableDebugger, override",
+			&Metadata{DebuggerPort: 1},
+			&Metadata{DebuggerPort: 2},
+			&Metadata{DebuggerPort: 2},
+		},
+		{
+			"EnableDebugger, not set",
+			&Metadata{DebuggerPort: 0},
+			&Metadata{DebuggerPort: 0},
+			&Metadata{DebuggerPort: 0},
 		},
 	}
 

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -45,6 +45,8 @@ py_web_test_suite(
         },
         "//browsers/sauce:chrome55-win10": {"tags": [
             "requires-network",
+            # TODO(DrMarcII) Figure out why this test is not working
+            "noci",
             "sauce",
         ]},
     },

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -55,6 +55,7 @@ py_web_test_suite(
         "//browsers:firefox-native",
         "//browsers/sauce:chrome55-win10",
     ],
+    default_python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [":web"],
 )

--- a/testing/web/debugger/BUILD
+++ b/testing/web/debugger/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,4 +21,6 @@ licenses(["notice"])  # Apache 2.0
 py_binary(
     name = "debugger",
     srcs = glob(["*.py"]),
+    default_python_version = "PY3",
+    srcs_version = "PY2AND3",
 )

--- a/testing/web/debugger/BUILD
+++ b/testing/web/debugger/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+package(default_testonly = True)
+
+licenses(["notice"])  # Apache 2.0
+
+py_binary(
+    name = "debugger",
+    srcs = glob(["*.py"]),
+)

--- a/testing/web/debugger/debugger.py
+++ b/testing/web/debugger/debugger.py
@@ -1,0 +1,156 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Web Test Launcher Debugger Front-End."""
+
+import code
+import json
+import socket
+import sys
+
+
+class Debugger:
+  """Debugger connects to the WTL debugger and sends and receives messages."""
+
+  def __init__(self, port, host="localhost"):
+    self._conn = socket.create_connection(address=(host, port))
+    self._file = self._conn.makefile()
+    self._decoder = json.JSONDecoder()
+    self._next_id = 1
+    self._buffer = ""
+
+  def _get_next_id(self):
+    id = self._next_id
+    self._next_id = self._next_id + 1
+    return id
+
+  def _read_next(self):
+    while True:
+      try:
+        self._buffer = self._buffer.strip()
+        obj, p = self._decoder.raw_decode(self._buffer)
+        self._buffer = self._buffer[p:]
+        return obj
+      except:
+        pass
+      s = self._conn.recv(4096)
+      if s == "":
+        quit()
+      self._buffer = self._buffer + s
+
+  def _read_until_waiting(self):
+    while True:
+      n = self._read_next()
+      print(n)
+      if n["status"] != "running":
+        return
+
+  def step(self):
+    """Execute the waiting WebDriver command and stop at the next one."""
+    id = self._get_next_id()
+    json.dump(obj={"id": id, "command": "step"}, fp=self._file)
+    self._file.flush()
+    self._read_until_waiting()
+
+  def run(self):
+    """Execute WebDriver commands until a breakpoint is reached."""
+    id = self._get_next_id()
+    json.dump(obj={"id": id, "command": "continue"}, fp=self._file)
+    self._file.flush()
+    self._read_until_waiting()
+
+  def stop(self):
+    """Quit WTL and the debugger."""
+    id = self._get_next_id()
+    json.dump(obj={"id": id, "command": "stop"}, fp=self._file)
+    self._file.flush()
+    quit()
+
+  def set_breakpoint(self, path=None, methods=None):
+    """Set a WTL breakpoint.
+
+    Args:
+      path: string, Go regular expression to compare to WebDriver command
+        paths.
+      methods: list of strings, a list of HTTP methods ("POST", "GET", etc).
+    Returns:
+      int, id of the breakpoint (can be used in delete_breakpoint command).
+    """
+    id = self._get_next_id()
+
+    bp = {"id": id}
+    if path:
+      bp["path"] = path
+    if methods:
+      bp["methods"] = methods
+
+    json.dump(
+        obj={
+            "id": id,
+            "command": "set breakpoint",
+            "breakpoint": bp,
+        },
+        fp=self._file)
+    self._file.flush()
+    self._read_until_waiting()
+    return id
+
+  def delete_breakpoint(self, breakpoint_id):
+    """Delete a previously set WTL breakpoint.
+
+    Args:
+      breakpoint_id: int, id of the breakpoint to delete.
+    """
+    id = self._get_next_id()
+
+    json.dump(
+        obj={
+            "id": id,
+            "command": "delete breakpoint",
+            "breakpoint": {
+                "id": breakpoint_id
+            },
+        },
+        fp=self._file)
+    self._file.flush()
+    self._read_until_waiting()
+
+
+def main(args):
+  host = "localhost"
+  if len(args) == 2:
+    port = args[1]
+  elif len(args) == 3:
+    host = args[1]
+    port = args[2]
+  else:
+    print("Usage %s [host] port")
+    quit()
+
+  wtl = Debugger(host=host, port=port)
+
+  code.interact(
+      """
+\033[95m\033[1mPython Interactive Console\033[0m
+
+Debugger Commands:
+    wtl.run(): Run test until next WTL breakpoint.
+    wtl.step(): Execute the current waiting command and break at the next one.
+    wtl.stop(): Quit WTL and the Debugger.
+    help(wtl): Additional debugger commands.
+""",
+      local={"wtl": wtl})
+
+
+if __name__ == "__main__":
+  main(sys.argv)

--- a/testing/web/webtest_test.py
+++ b/testing/web/webtest_test.py
@@ -14,12 +14,14 @@
 """Tests for testing.web.webtest."""
 
 import unittest
+
 from testing.web import webtest
 
 
 class BrowserTest(unittest.TestCase):
 
   def testBrowserProvisioningNoCaps(self):
+    pass
     driver = webtest.new_webdriver_session()
 
     try:

--- a/web/internal/web_test.sh.template
+++ b/web/internal/web_test.sh.template
@@ -42,21 +42,17 @@ args=()
 portatnext=0
 debuggerport=0
 
-for var in $@; do
-  if [[ $portatnext > 0 ]]; then
-    debuggerport=$var
+for var in "$@"; do
+  if (( "$portatnext" )); then
+    debuggerport="$var"
     portatnext=0
-    continue
-  fi
-  if [[ $var = --debugger_port=* ]]; then
-    debuggerport=${var#--debugger_port=}
-    continue
-  fi
-  if [[ $var == "--debugger_port" ]];  then
+  elif [[ "$var" == --debugger_port=* ]]; then
+    debuggerport="${var#--debugger_port=}"
+  elif [[ $var == "--debugger_port" ]];  then
     portatnext=1
-    continue
+  else
+    args+=("$var")
   fi
-  args+=($var)
 done
 
 "$TEST_SRCDIR/%TEMPLATED_launcher%" \

--- a/web/internal/web_test.sh.template
+++ b/web/internal/web_test.sh.template
@@ -48,7 +48,7 @@ for var in "$@"; do
     portatnext=0
   elif [[ "$var" == --debugger_port=* ]]; then
     debuggerport="${var#--debugger_port=}"
-  elif [[ $var == "--debugger_port" ]];  then
+  elif [[ "$var" == "--debugger_port" ]];  then
     portatnext=1
   else
     args+=("$var")

--- a/web/internal/web_test.sh.template
+++ b/web/internal/web_test.sh.template
@@ -38,4 +38,29 @@ fi
 
 printenv
 
-"$TEST_SRCDIR/%TEMPLATED_launcher%" --metadata="%TEMPLATED_metadata%" --test="%TEMPLATED_test%"
+args=()
+portatnext=0
+debuggerport=0
+
+for var in $@; do
+  if [[ $portatnext > 0 ]]; then
+    debuggerport=$var
+    portatnext=0
+    continue
+  fi
+  if [[ $var = --debugger_port=* ]]; then
+    debuggerport=${var#--debugger_port=}
+    continue
+  fi
+  if [[ $var == "--debugger_port" ]];  then
+    portatnext=1
+    continue
+  fi
+  args+=($var)
+done
+
+"$TEST_SRCDIR/%TEMPLATED_launcher%" \
+  --metadata="%TEMPLATED_metadata%" \
+  --test="%TEMPLATED_test%" \
+  --debugger_port="$debuggerport" \
+  -- "$args"


### PR DESCRIPTION
Example usage:

In terminal A:
bazel build testing/web/debugger:debugger
bazel test --test_output=streamed --test_arg=--debugger_port=49157 \
    go/webtest:go_default_test_chromium-native

In terminal B:
bazel-bin/testing/web/debugger/debugger 49157