### PR TITLE
Use floats instead of ints when unmarshalling JSON.

### DIFF
--- a/go/launcher/webdriver/webdriver.go
+++ b/go/launcher/webdriver/webdriver.go
@@ -80,9 +80,9 @@ type WebDriver interface {
 	// SetWindowRect sets the current window size and location.
 	SetWindowRect(context.Context, Rectangle) error
 	// SetWindowSize sets the current window size.
-	SetWindowSize(ctx context.Context, width, height uint64) error
+	SetWindowSize(ctx context.Context, width, height float64) error
 	// SetWindowPosition sest the current window position.
-	SetWindowPosition(ctx context.Context, x, y int64) error
+	SetWindowPosition(ctx context.Context, x, y float64) error
 	// W3C return true iff connected to a W3C compliant remote end.
 	W3C() bool
 }
@@ -103,10 +103,10 @@ type WebElement interface {
 
 // Rectangle represents a window's position and size.
 type Rectangle struct {
-	X      int64  `json:"x"`
-	Y      int64  `json:"y"`
-	Width  uint64 `json:"width"`
-	Height uint64 `json:"height"`
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
 }
 
 // LogEntry is an entry parsed from the logs retrieved from the remote WebDriver.
@@ -391,8 +391,8 @@ func (d *webDriver) SetWindowRect(ctx context.Context, rect Rectangle) error {
 	return d.SetWindowPosition(ctx, rect.X, rect.Y)
 }
 
-func (d *webDriver) SetWindowSize(ctx context.Context, width, height uint64) error {
-	args := map[string]uint64{
+func (d *webDriver) SetWindowSize(ctx context.Context, width, height float64) error {
+	args := map[string]float64{
 		"width":  width,
 		"height": height,
 	}
@@ -403,8 +403,8 @@ func (d *webDriver) SetWindowSize(ctx context.Context, width, height uint64) err
 	return d.post(ctx, command, args, nil)
 }
 
-func (d *webDriver) SetWindowPosition(ctx context.Context, x, y int64) error {
-	args := map[string]int64{
+func (d *webDriver) SetWindowPosition(ctx context.Context, x, y float64) error {
+	args := map[string]float64{
 		"x": x,
 		"y": y,
 	}

--- a/go/launcher/webdriver/webdriver_test.go
+++ b/go/launcher/webdriver/webdriver_test.go
@@ -411,8 +411,8 @@ func TestSetWindowSize(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		width  uint64
-		height uint64
+		width  float64
+		height float64
 		check  bool
 		err    bool
 	}{
@@ -486,8 +486,8 @@ func TestSetWindowPosition(t *testing.T) {
 
 	testCases := []struct {
 		name  string
-		x     int64
-		y     int64
+		x     float64
+		y     float64
 		check bool
 		err   bool
 	}{


### PR DESCRIPTION
JSON, like JavaScript (naturally), has a single number type. Drivers may serialize numbers as floats, even if the numbers are intended to be integers. Lots of JSON libraries tack a ".0" on the ends of integers, so we should just be tolerant of float-y numbers.

PiperOrigin-RevId: 162693557