### PR TITLE
Define native Chrome/Windows.

### DIFF
--- a/browsers/BUILD
+++ b/browsers/BUILD
@@ -32,6 +32,12 @@ config_setting(
     visibility = ["//:__subpackages__"],
 )
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//:__subpackages__"],
+)
+
 browser(
     name = "firefox-external",
     metadata = "firefox-external.json",
@@ -69,6 +75,7 @@ browser(
     environment = select({
         ":linux": None,
         ":mac": {"DISABLE_X_DISPLAY": "1"},
+        ":windows": {"DISABLE_X_DISPLAY": "1"},
     }),
     metadata = "chromium-native.json",
     required_tags = [

--- a/third_party/chromium/BUILD
+++ b/third_party/chromium/BUILD
@@ -35,6 +35,11 @@ config_setting(
     values = {"cpu": "k8"},
 )
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
 web_test_archive(
     name = "chromium",
     archive = "@org_chromium_chromium//file",
@@ -44,6 +49,9 @@ web_test_archive(
         },
         ":mac": {
             "CHROME": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
+        },
+        ":windows": {
+            "CHROME": "chrome-win32/chrome.exe",
         },
     }),
 )

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -18,6 +18,9 @@ def _impl(repository_ctx):
   if repository_ctx.os.name.lower().startswith("mac os"):
     urls = repository_ctx.attr.macos_urls
     sha256 = repository_ctx.attr.macos_sha256
+  elif repository_ctx.os.name.lower().startswith("windows"):
+    urls = repository_ctx.attr.windows_urls
+    sha256 = repository_ctx.attr.windows_sha256
   else:
     urls = repository_ctx.attr.amd64_urls
     sha256 = repository_ctx.attr.amd64_sha256
@@ -42,4 +45,6 @@ platform_http_file = repository_rule(
         "amd64_sha256": attr.string(),
         "macos_urls": attr.string_list(),
         "macos_sha256": attr.string(),
+        "windows_urls": attr.string_list(),
+        "windows_sha256": attr.string(),
     })

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -409,6 +409,11 @@ def org_chromium_chromedriver():
       "6c30bba7693ec2d9af7cd9a54729e10aeae85c0953c816d9c4a40a1a72fd8be0",
       macos_urls=[
           "http://chromedriver.storage.googleapis.com/2.29/chromedriver_mac64.zip"
+      ],
+      windows_sha256=
+      "d04084021ddd87400e9eddbee8648c97d429f038f54fe06b279584eee441a4b1",
+      windows_urls=[
+          "http://chromedriver.storage.googleapis.com/2.29/chromedriver_win32.zip"
       ])
 
 
@@ -425,6 +430,11 @@ def org_chromium_chromium():
       "740d691b07855e2aace1e524fd67b8732458e52cc8fca0b4c1bddbbb3aa9ee11",
       macos_urls=[
           "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/454475/chrome-mac.zip"
+      ],
+      windows_sha256=
+      "1093602bb16a2a68bdd9b6dba1d3a998b2a6bfbdf3a0afff613c38a960e37d9c",
+      windows_urls=[
+          "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Win/454494/chrome-win32.zip"
       ])
 
 


### PR DESCRIPTION
Define native Chrome/Windows. See #178.

This is the initial definition of a native Chrome/Windows
configuration. Note that this does not yet work due to
the @io_bazel_rules_go_toolchain// release not yet
supporting Windows 10 (and potentially other yet-to-be-
discovered issues).