### PR TITLE
Make an environment health check err non-permanent

### DIFF
--- a/go/launcher/environment/environment.go
+++ b/go/launcher/environment/environment.go
@@ -121,7 +121,7 @@ func (b *Base) Healthy(context.Context) error {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if !b.started {
-		return errors.NewPermanent(b.Name(), "has not been started")
+		return errors.New(b.Name(), "has not been started")
 	}
 	if b.stopped {
 		return errors.NewPermanent(b.Name(), "has been stopped")


### PR DESCRIPTION
Environment setup may not complete before the initial health check. If the environment is not yet started, it is unhealthy, but this may not be a permanent state. Adjust the error returned accordingly.