### PR TITLE
Stop recognizing "google." prefix for Google-internal capabilities. O…

### DIFF
--- a/go/metadata/capabilities/capabilities.go
+++ b/go/metadata/capabilities/capabilities.go
@@ -184,18 +184,14 @@ func sliceEquals(e, v []interface{}) bool {
 	return true
 }
 
-// GoogleCap returns the value of a Google capability from the given
-// Spec. Google capabilities are currently only extracted from the OSS specs,
-// but this will eventually change to recognize vendor-prefixed capabilities in
-// the W3C spec as well.
+// GoogleCap returns the value of a Google capability from the given Spec. It
+// searches for the capability in the W3C capabilities first, and then in the
+// OSS capabilities.
 func GoogleCap(caps Spec, name string) interface{} {
 	if v, ok := caps.Always["google:"+name]; ok {
 		return v
 	}
 	if v, ok := caps.OSSCaps["google:"+name]; ok {
-		return v
-	}
-	if v, ok := caps.OSSCaps["google."+name]; ok {
 		return v
 	}
 	return nil
@@ -209,9 +205,6 @@ func HasGoogleCap(caps Spec, name string) bool {
 	if _, ok := caps.OSSCaps["google:"+name]; ok {
 		return true
 	}
-	if _, ok := caps.OSSCaps["google."+name]; ok {
-		return true
-	}
 	return false
 }
 
@@ -219,7 +212,6 @@ func HasGoogleCap(caps Spec, name string) bool {
 func SetGoogleCap(caps Spec, name string, value interface{}) {
 	if caps.OSSCaps != nil {
 		caps.OSSCaps["google:"+name] = value
-		caps.OSSCaps["google."+name] = value
 	}
 	if caps.Always != nil {
 		caps.Always["google:"+name] = value

--- a/go/metadata/capabilities/capabilities_test.go
+++ b/go/metadata/capabilities/capabilities_test.go
@@ -423,8 +423,8 @@ func TestGoogleCap(t *testing.T) {
 		},
 		{
 			"found only in oss caps",
-			Spec{OSSCaps: map[string]interface{}{"google.capName": "vvvvvv", "google:otherCap": "xxx"}},
-			[]kv{{"capName", "vvvvvv"}, {"otherCap", "xxx"}},
+			Spec{OSSCaps: map[string]interface{}{"google:otherCap": "xxx"}},
+			[]kv{{"otherCap", "xxx"}},
 		},
 		{
 			"found only in w3c caps",
@@ -477,7 +477,7 @@ func TestSetGoogleCap(t *testing.T) {
 			},
 			"capName", "vvvvvv",
 			Spec{
-				OSSCaps: map[string]interface{}{"google.capName": "vvvvvv", "google:capName": "vvvvvv"},
+				OSSCaps: map[string]interface{}{"google:capName": "vvvvvv"},
 				Always:  map[string]interface{}{"google:capName": "vvvvvv"},
 			},
 		},
@@ -498,7 +498,7 @@ func TestSetGoogleCap(t *testing.T) {
 			},
 			"capName", "vvvvvv",
 			Spec{
-				OSSCaps: map[string]interface{}{"google.capName": "vvvvvv", "google:capName": "vvvvvv"},
+				OSSCaps: map[string]interface{}{"google:capName": "vvvvvv"},
 			},
 		},
 		{
@@ -509,7 +509,7 @@ func TestSetGoogleCap(t *testing.T) {
 			},
 			"capName", "vvvvvv",
 			Spec{
-				OSSCaps: map[string]interface{}{"google:capName": "vvvvvv", "google.capName": "vvvvvv"},
+				OSSCaps: map[string]interface{}{"google:capName": "vvvvvv"},
 				Always:  map[string]interface{}{"google:capName": "vvvvvv"},
 			},
 		},
@@ -521,7 +521,7 @@ func TestSetGoogleCap(t *testing.T) {
 			},
 			"capName", "vvvvvv",
 			Spec{
-				OSSCaps: map[string]interface{}{"google:capName": "vvvvvv", "google.capName": "vvvvvv", "capName": "xyz"},
+				OSSCaps: map[string]interface{}{"google:capName": "vvvvvv", "capName": "xyz"},
 				Always:  map[string]interface{}{"google:capName": "vvvvvv", "capName": "xyz"},
 			},
 		},


### PR DESCRIPTION
…nly "google:" will be recognized from now on, consistent with the W3C WebDriver spec for vendor-prefixed capabilities.

PiperOrigin-RevId: 173203169