### PR TITLE
Use skylark_library rules to group bzl files, rather than filegroup.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,9 +36,9 @@ load("//web:repositories.bzl", "browser_repositories", "web_test_repositories")
 web_test_repositories()
 
 git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/bazelbuild/skydoc.git",
-    tag = "0.1.4",
+    name = "bazel_skylib",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
+    tag = "0.2.0",
 )
 
 browser_repositories(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,12 @@ load("//web:repositories.bzl", "browser_repositories", "web_test_repositories")
 
 web_test_repositories()
 
+git_repository(
+    name = "io_bazel_skydoc",
+    remote = "https://github.com/bazelbuild/skydoc.git",
+    tag = "0.1.4",
+)
+
 browser_repositories(
     chromium = True,
     firefox = True,

--- a/web/BUILD
+++ b/web/BUILD
@@ -17,7 +17,7 @@
 package(default_testonly = True)
 
 load(":web.bzl", "web_test_config")
-load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_library")
+load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/web/BUILD
+++ b/web/BUILD
@@ -17,6 +17,7 @@
 package(default_testonly = True)
 
 load(":web.bzl", "web_test_config")
+load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -30,17 +31,17 @@ web_test_config(
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "repositories",
     srcs = ["repositories.bzl"],
-    data = ["//web/internal:platform_http_file"],
+    deps = ["//web/internal:platform_http_file"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "web",
     srcs = ["web.bzl"],
-    data = [
+    deps = [
         "//web/internal:browser",
         "//web/internal:collections",
         "//web/internal:constants",
@@ -53,23 +54,23 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "go",
     srcs = ["go.bzl"],
-    data = [
+    deps = [
         "//web/internal:wrap_web_test_suite",
         # should depend on go build rules.
     ],
 )
 
-filegroup(
+skylark_library(
     name = "java",
     srcs = ["java.bzl"],
-    data = ["//web/internal:wrap_web_test_suite"],
+    deps = ["//web/internal:wrap_web_test_suite"],
 )
 
-filegroup(
+skylark_library(
     name = "py",
     srcs = ["py.bzl"],
-    data = ["//web/internal:wrap_web_test_suite"],
+    deps = ["//web/internal:wrap_web_test_suite"],
 )

--- a/web/internal/BUILD
+++ b/web/internal/BUILD
@@ -16,7 +16,7 @@
 #
 package(default_testonly = True)
 
-load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_library")
+load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/web/internal/BUILD
+++ b/web/internal/BUILD
@@ -16,6 +16,8 @@
 #
 package(default_testonly = True)
 
+load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_library")
+
 licenses(["notice"])  # Apache 2.0
 
 exports_files(
@@ -28,49 +30,49 @@ exports_files(
     visibility = ["//doc:__pkg__"],
 )
 
-filegroup(
+skylark_library(
     name = "browser",
     srcs = ["browser.bzl"],
-    data = [":metadata"],
+    deps = [":metadata"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "collections",
     srcs = ["collections.bzl"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "constants",
     srcs = ["constants.bzl"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "files",
     srcs = ["files.bzl"],
-    data = [":collections"],
+    deps = [":collections"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "metadata",
     srcs = ["metadata.bzl"],
-    data = [":files"],
+    deps = [":files"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "platform_http_file",
     srcs = ["platform_http_file.bzl"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "web_test",
     srcs = ["web_test.bzl"],
-    data = [
+    deps = [
         ":collections",
         ":files",
         ":metadata",
@@ -78,38 +80,38 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "web_test_archive",
     srcs = ["web_test_archive.bzl"],
-    data = [":metadata"],
+    deps = [":metadata"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "web_test_config",
     srcs = ["web_test_config.bzl"],
-    data = [":metadata"],
+    deps = [":metadata"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "web_test_named_executable",
     srcs = ["web_test_named_executable.bzl"],
-    data = [":metadata"],
+    deps = [":metadata"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "web_test_named_file",
     srcs = ["web_test_named_file.bzl"],
-    data = [":metadata"],
+    deps = [":metadata"],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
+skylark_library(
     name = "wrap_web_test_suite",
     srcs = ["wrap_web_test_suite.bzl"],
-    data = [
+    deps = [
         ":constants",
         "//web",
     ],


### PR DESCRIPTION
skylark_library rule allows dependency resolution, which makes it easier to manage rules depending on large number of .bzl files. skylark_library will work in data section of other rules, so that it won't break existing users.