### PR TITLE
Strip x-google- prefixed headers

### DIFF
--- a/go/wtl/proxy/driverhub/driver_session.go
+++ b/go/wtl/proxy/driverhub/driver_session.go
@@ -295,8 +295,10 @@ func createBaseHandler(driver webdriver.WebDriver) HandlerFunc {
 			return Response{}, err
 		}
 		req = req.WithContext(ctx)
-		if rq.Header != nil {
-			req.Header = rq.Header
+		for k, v := range rq.Header {
+			if !strings.HasPrefix(k, "x-google-") {
+				req.Header[k] = v
+			}
 		}
 
 		resp, err := client.Do(req)


### PR DESCRIPTION
Strip x-google- prefixed headers when forwarding requests with WTL as
WTL is expected to process any.