### PR TITLE
Add Scala test support, deb support, and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ http_archive(
         "https://github.com/bazelbuild/rules_go/archive/master.tar.gz",
     ],
 )
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
-
-go_repositories()
+# Load rules_webtesting at master for example purposes only. You should specify
+# a specific version in your project.
+http_archive(
+    name = "bazel_skylib",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/master.tar.gz",
+)
 
 # Load rules_webtesting at master for example purposes only. You should specify
 # a specific version in your project.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,28 +16,31 @@
 #
 workspace(name = "io_bazel_rules_webtesting")
 
+skylib_version = "f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5"
 http_archive(
     name = "bazel_skylib",
     sha256 = "ce27a2007deda8a1de65df9de3d4cd93a5360ead43c5ff3017ae6b3a2abe485e",
-    strip_prefix = "bazel-skylib-f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5",
+    strip_prefix= "bazel-skylib-{v}".format(v=skylib_version),
     urls = [
-        "https://github.com/bazelbuild/bazel-skylib/archive/f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5.tar.gz",
-    ],
+        "https://github.com/bazelbuild/bazel-skylib/archive/{v}.tar.gz".format(v=skylib_version)
+    ]
 )
 
+rules_go_version = "0.10.0"
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "53c8222c6eab05dd49c40184c361493705d4234e60c42c4cd13ab4898da4c6be",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.10.0/rules_go-0.10.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.10.0/rules_go-0.10.0.tar.gz",
+        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/{v}/rules_go-{v}.tar.gz".format(v=rules_go_version),
+        "https://github.com/bazelbuild/rules_go/releases/download/{v}/rules_go-{v}.tar.gz".format(v=rules_go_version),
     ],
 )
 
+gazelle_version = "0.10.0"
 http_archive(
     name = "bazel_gazelle",
     sha256 = "6228d9618ab9536892aa69082c063207c91e777e51bd3c5544c9c060cafe1bd8",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.0/bazel-gazelle-0.10.0.tar.gz",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/{v}/bazel-gazelle-{v}.tar.gz".format(v=gazelle_version),
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
@@ -58,3 +61,18 @@ browser_repositories(
     chromium = True,
     firefox = True,
 )
+
+rules_scala_version = "55c5bd2c4af311008bcfa0f989af39026ed567fe"
+http_archive(
+  name = "io_bazel_rules_scala",
+  url = "https://github.com/bazelbuild/rules_scala/archive/{v}.zip".format(v=rules_scala_version),
+  strip_prefix= "rules_scala-{v}".format(v=rules_scala_version),
+  sha256 = "d45b5d621f216eee004e1aaed0f9f9df43c75f55c81fa742b27fc6969d2cbc2b",
+  type = "zip",
+)
+
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+scala_repositories()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+scala_register_toolchains()

--- a/go/metadata/web_test_files.go
+++ b/go/metadata/web_test_files.go
@@ -187,6 +187,8 @@ func (w *WebTestFiles) extract() error {
 		c = exec.Command("tar", "xZf", filename, "-C", extractPath)
 	case strings.HasSuffix(filename, ".zip"):
 		c = exec.Command("unzip", filename, "-d", extractPath)
+	case strings.HasSuffix(filename, ".deb"):
+		c = exec.Command("dpkg", "-x", filename, extractPath)
 	default:
 		return fmt.Errorf("unknown archive type: %s", filename)
 	}

--- a/scalatests/com/google/testing/web/BUILD.bazel
+++ b/scalatests/com/google/testing/web/BUILD.bazel
@@ -1,0 +1,47 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+package(default_testonly = True)
+
+licenses(["notice"])  # Apache 2.0
+
+load("//web:scala.bzl", "scala_web_test_suite")
+
+scala_web_test_suite(
+    name = "WebTestTest",
+    srcs = ["WebTestTest.scala"],
+    browser_overrides = {
+        "//browsers:chromium-local": {
+            "tags": ["noci"],
+        },
+        "//browsers:firefox-local": {
+            "tags": ["noci"],
+        },
+        "//browsers/sauce:chrome-win10": {
+            "tags": ["sauce"],
+        },
+    },
+    browsers = [
+        "//browsers:chromium-local",
+        "//browsers:firefox-local",
+        "//browsers/sauce:chrome-win10",
+    ],
+    deps = [
+        "//java/com/google/testing/web",
+        "@junit",
+        "@org_seleniumhq_selenium_api",
+    ],
+)

--- a/scalatests/com/google/testing/web/WebTestTest.scala
+++ b/scalatests/com/google/testing/web/WebTestTest.scala
@@ -1,0 +1,30 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// //////////////////////////////////////////////////////////////////////////////
+//
+package com.google.testing.web;
+
+import org.openqa.selenium.WebDriver
+import org.scalatest._
+
+class WebTestTest extends WordSpec {
+
+  "A WebDriver" should {
+    "start and stop" in {
+      val driver = new WebTest().newWebDriverSession()
+      driver.quit()
+    }
+  }
+}

--- a/scalatests/com/google/testing/web/screenshotter/BUILD.bazel
+++ b/scalatests/com/google/testing/web/screenshotter/BUILD.bazel
@@ -1,0 +1,47 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+package(default_testonly = True)
+
+licenses(["notice"])  # Apache 2.0
+
+load("//web:scala.bzl", "scala_web_test_suite")
+
+scala_web_test_suite(
+    name = "ScreenshotterTest",
+    srcs = ["ScreenshotterTest.scala"],
+    browser_overrides = {
+        "//browsers:chromium-native": {
+            "tags": ["noci"],
+        },
+        "//browsers:firefox-native": {
+            "tags": ["noci"],
+        },
+    },
+    browsers = [
+        "//browsers:chromium-local",
+        "//browsers:firefox-local",
+    ],
+    data = ["//testdata"],
+    deps = [
+        "//java/com/google/testing/bazel",
+        "//java/com/google/testing/web",
+        "//java/com/google/testing/web/screenshotter",
+        "@junit",
+        "@org_json",
+        "@org_seleniumhq_selenium_api",
+    ],
+)

--- a/scalatests/com/google/testing/web/screenshotter/ScreenshotterTest.scala
+++ b/scalatests/com/google/testing/web/screenshotter/ScreenshotterTest.scala
@@ -1,0 +1,89 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// //////////////////////////////////////////////////////////////////////////////
+//
+package com.google.testing.web.screenshotter;
+
+import com.google.testing.bazel.Bazel
+import com.google.testing.web.WebTest
+import java.awt.Image
+import java.nio.file.Files
+import java.nio.file.Path
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.scalatest._
+
+class ScreenshotterTest
+  extends WordSpec
+  with BeforeAndAfter
+  with BeforeAndAfterAll
+  with Matchers {
+
+  var tmpDir: Path = _
+
+  private var driver: WebDriver = _
+  private var screenshotter: Screenshotter = _
+
+  override def beforeAll() = {
+    tmpDir = Bazel.getInstance.newTmpDir(this.getClass.getSimpleName)
+  }
+
+  before {
+    driver = new WebTest().newWebDriverSession()
+    screenshotter = new Screenshotter(driver)
+    driver.get(Bazel.getInstance.runfile("testdata/testpage.html").toUri.toString)
+  }
+
+
+  after {
+    try {
+      driver.quit()
+    } finally {
+      driver = null
+      screenshotter = null
+    }
+  }
+
+  "A WebDriver" should {
+    "take a screenshot" in {
+      val ss = screenshotter.takeScreenshot()
+      val out = tmpDir.resolve("basicScreenshot.png")
+      Files.write(out, ss.asBytes())
+      System.out.println("image written to: " + out)
+      // No assertions. Check output manually.
+    }
+
+    "take a screenshot of an element" in {
+      val ss = screenshotter.of(driver.findElement(By.tagName("input"))).takeScreenshot()
+      val out = tmpDir.resolve("ofInputElement.png")
+      Files.write(out, ss.asBytes())
+      System.out.println("image written to: " + out)
+      val img = ss.asImage()
+      200 shouldEqual img.getHeight(null)
+      200 shouldEqual img.getWidth(null)
+    }
+
+    "exclude elements from a screenshot" in {
+      val ss = screenshotter
+        .of(driver.findElement(By.id("outer-div")))
+        .excluding(driver.findElement(By.id("inner-div1")), driver.findElement(By.id("b")))
+        .takeScreenshot()
+      val out = tmpDir.resolve("excludingElements.png")
+      Files.write(out, ss.asBytes())
+      System.out.println("image written to: " + out)
+      // No assertions. Check output manually.
+    }
+  }
+}

--- a/web/internal/web_test_archive.bzl
+++ b/web/internal/web_test_archive.bzl
@@ -63,6 +63,7 @@ web_test_archive = rule(
                     ".tgz",
                     ".tar.Z",
                     ".zip",
+                    ".deb",
                 ],
                 mandatory=True),
         "data":

--- a/web/scala.bzl
+++ b/web/scala.bzl
@@ -1,0 +1,32 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Web Test rules for Java."""
+
+load("//web/internal:wrap_web_test_suite.bzl", "wrap_web_test_suite")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+
+
+def scala_web_test_suite(name, scala_test_tags=None, **kwargs):
+  """Defines a test_suite of web_test targets that wrap a java_test target.
+
+  Args:
+    name: The base name of the test.
+    scala_test_tags: A list of test tag strings to use for the scala_test target.
+    **kwargs: Arguments for wrapped_web_test_suite
+  """
+  wrap_web_test_suite(
+      name=name,
+      rule=scala_test,
+      wrapped_test_tags=scala_test_tags,
+      **kwargs)


### PR DESCRIPTION
We're moving to Bazel at Lucid, and we are running a trial for our Selenium tests using rules_webtesting. Our tests are in Scala, which I added support for. I also updated the README to include what I found as I was using rules_webtesting. I also added support for debs to make it easier for us to download browsers.