### PR TITLE
Cleanup rules.

### DIFF
--- a/go/metadata/capabilities/capabilities_test.go
+++ b/go/metadata/capabilities/capabilities_test.go
@@ -155,7 +155,7 @@ func TestMerge(t *testing.T) {
 					"an option",
 					"--anOption=false",
 					"--anotherOption",
-					"-optionToLeave=that",		
+					"-optionToLeave=that",
 					map[string]interface{}{
 						"some": "map",
 					},
@@ -171,7 +171,7 @@ func TestMerge(t *testing.T) {
 					"an option",
 					"--anOption=false",
 					"--anotherOption",
-					"-optionToLeave=that",	
+					"-optionToLeave=that",
 					map[string]interface{}{
 						"some": "map",
 					},

--- a/web/internal/runfiles.bzl
+++ b/web/internal/runfiles.bzl
@@ -1,0 +1,60 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runfiles modules contains utility functions for working with runfiles."""
+
+
+def _collect(ctx, files=[], targets=[]):
+  """Builds a runfiles object with transitive files from all targets.
+
+  Args:
+    ctx: Context object for the rule where this being used.
+    files: a list of File object to include in the runfiles.
+    targets: a list of Target object from which runfiles will be collected.
+  
+  Returns:
+    A configured runfiles object that include data and default runfiles for the
+    rule, all transitive runfiles from targets, and all files from files.
+  """
+  transitive_runfiles = depset()
+  dep_files = depset()
+  default_runfiles = []
+  data_runfiles = []
+
+  for target in targets:
+    if hasattr(target, "transitive_runfiles"):
+      transitive_runfiles = depset(
+          transitive=[transitive_runfiles, target.transitive_runfiles])
+    if hasattr(target, "default_runfiles"):
+      default_runfiles += [target.default_runfiles]
+    if hasattr(target, "data_runfiles"):
+      data_runfiles += [target.data_runfiles]
+    if hasattr(target, "files"):
+      dep_files = depset(transitive=[dep_files, target.files])
+
+  result = ctx.runfiles(
+      collect_data=True,
+      collect_default=True,
+      files=files + dep_files.to_list(),
+      transitive_files=transitive_runfiles)
+
+  for default in default_runfiles:
+    result = result.merge(default)
+
+  for data in data_runfiles:
+    result = result.merge(data)
+
+  return result
+
+
+runfiles = struct(collect=_collect,)

--- a/web/internal/web_test_archive.bzl
+++ b/web/internal/web_test_archive.bzl
@@ -18,13 +18,13 @@ DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 
 load("//web/internal:metadata.bzl", "metadata")
 load("//web/internal:provider.bzl", "WebTestInfo")
+load("//web/internal:runfiles.bzl", "runfiles")
 
 
 def _web_test_archive_impl(ctx):
-  patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
   metadata.create_file(
       ctx=ctx,
-      output=patch,
+      output=ctx.outputs.web_test_metadata,
       web_test_files=[
           metadata.web_test_files(
               ctx=ctx,
@@ -32,30 +32,24 @@ def _web_test_archive_impl(ctx):
               named_files=ctx.attr.named_files),
       ])
 
-  metadata_files = [patch
-                   ] + [dep[WebTestInfo].metadata for dep in ctx.attr.deps]
-
-  metadata.merge_files(
-      ctx=ctx,
-      merger=ctx.executable.merger,
-      output=ctx.outputs.web_test_metadata,
-      inputs=metadata_files)
-
   return [
-      DefaultInfo(
-          runfiles=ctx.runfiles(
-              collect_data=True, collect_default=True, files=[ctx.file.archive
-                                                             ])),
+      DefaultInfo(runfiles=ctx.runfiles(files=[ctx.file.archive])),
       WebTestInfo(metadata=ctx.outputs.web_test_metadata),
   ]
 
 
 web_test_archive = rule(
+    doc="""Specifies an archive file with named files in it.
+
+The archive will be unzipped only if Web Test Launcher wants one the named
+files in the archive.""",
     implementation=_web_test_archive_impl,
     attrs={
         "archive":
             attr.label(
+                doc="Archive file that contains named files.",
                 allow_single_file=[
+                    ".deb",
                     ".tar",
                     ".tar.bz2",
                     ".tbz2",
@@ -63,32 +57,11 @@ web_test_archive = rule(
                     ".tgz",
                     ".tar.Z",
                     ".zip",
-                    ".deb",
                 ],
                 mandatory=True),
-        "data":
-            attr.label_list(allow_files=True, cfg="data"),
-        "deps":
-            attr.label_list(providers=[WebTestInfo]),
-        "merger":
-            attr.label(
-                executable=True,
-                cfg="host",
-                default=Label("//go/metadata/main")),
         "named_files":
-            attr.string_dict(mandatory=True),
+            attr.string_dict(
+                doc="A map of names to paths in the archive.", mandatory=True),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
 )
-"""Specifies an archive file with named files in it.
-
-The archive will be unzipped only if Web Test Launcher wants one the named
-files in the archive.
-
-Args:
-  archive: Archive file that contains named files.
-  data: Runtime dependencies for this rule.
-  deps: Other web_test-related rules that this rule depends on.
-  merger: Metadata merger executable.
-  named_files: A map of names to paths in the archive.
-"""

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -49,27 +49,26 @@ def _web_test_config_impl(ctx):
 
 
 web_test_config = rule(
+    doc="A configuration that can be used across multiple web_tests.",
     attrs={
         "data":
-            attr.label_list(allow_files=True, cfg="data"),
+            attr.label_list(
+                doc="Runtime dependencies for this configuration.",
+                allow_files=True,
+                cfg="data"),
         "deps":
-            attr.label_list(providers=[WebTestInfo]),
+            attr.label_list(
+                doc="Other web_test-related rules that this rule depends on.",
+                providers=[WebTestInfo]),
         "merger":
             attr.label(
+                doc="Metadata merger executable.",
                 executable=True,
                 cfg="host",
                 default=Label("//go/metadata/main")),
         "metadata":
-            attr.label(allow_single_file=[".json"]),
+            attr.label(
+                doc="A web_test metadata file.", allow_single_file=[".json"]),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
     implementation=_web_test_config_impl)
-"""A browser-independent configuration that can be used across multiple web_tests.
-
-Args:
-  data: Runtime dependencies for this configuration.
-  deps: Other web_test-related rules that this rule depends on.
-  merger: Metadata merger executable.
-  metadata: A web_test metadata file with configuration that will override
-    all other configuration.
-"""

--- a/web/internal/wrap_web_test_suite.bzl
+++ b/web/internal/wrap_web_test_suite.bzl
@@ -26,13 +26,13 @@ def wrap_web_test_suite(name,
                         flaky=None,
                         local=None,
                         shard_count=None,
-                        size="large",
+                        size=None,
                         tags=None,
                         test_suite_tags=None,
                         timeout=None,
                         visibility=None,
                         web_test_data=None,
-                        wrapped_test_tags=DEFAULT_WRAPPED_TEST_TAGS,
+                        wrapped_test_tags=None,
                         **remaining_keyword_args):
   """Defines a test_suite of web_test targets that wrap a given rule.
 
@@ -61,8 +61,11 @@ def wrap_web_test_suite(name,
     **remaining_keyword_args: Arguments for the wrapped test target.
   """
 
+  # Check explicitly for None so that users can set this to the empty list
   if wrapped_test_tags == None:
     wrapped_test_tags = DEFAULT_WRAPPED_TEST_TAGS
+
+  size = size or "large"
 
   wrapped_test_name = name + "_wrapped_test"
 

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -40,9 +40,8 @@ load("//web/internal:web_test_files.bzl", web_test_files_alias="web_test_files")
 
 def web_test_suite(name,
                    browsers,
-                   test,
                    browser_overrides=None,
-                   test_suite_tags=DEFAULT_TEST_SUITE_TAGS,
+                   test_suite_tags=None,
                    visibility=None,
                    **kwargs):
   """Defines a test_suite of web_test targets to be run.
@@ -50,8 +49,6 @@ def web_test_suite(name,
   Args:
     name: Name; required. A unique name for this rule.
     browsers: List of labels; required. The browsers with which to run the test.
-    test: Label; required. A single *_test or *_binary target. The test that
-      web_test should run with the specified browser.
     browser_overrides: Dictionary; optional; default is an empty dictionary. A
       dictionary mapping from browser names to browser-specific web_test
       attributes, such as shard_count, flakiness, timeout, etc. For example:
@@ -67,6 +64,7 @@ def web_test_suite(name,
   if not browsers:
     fail("expected non-empty value for attribute 'browsers'")
 
+  # Check explicitly for None so that users can set this to the empty list.
   if test_suite_tags == None:
     test_suite_tags = DEFAULT_TEST_SUITE_TAGS
 
@@ -86,7 +84,6 @@ def web_test_suite(name,
     web_test(
         name=test_name,
         browser=browser,
-        test=test,
         visibility=visibility,
         **overridden_kwargs)
     tests += [test_name]
@@ -113,61 +110,39 @@ def _apply_browser_overrides(kwargs, overrides):
   return overridden_kwargs
 
 
-def browser(deps=None, data=None, **kwargs):
+def browser(testonly=True, **kwargs):
   """Wrapper around browser to correctly set defaults."""
-  data = lists.clone(data)
-  if deps:
-    lists.ensure_contains_all(data, deps)
-  browser_alias(data=data, deps=deps, testonly=True, **kwargs)
+  browser_alias(testonly=testonly, **kwargs)
 
 
-def web_test(
-    browser,  # pylint: disable=redefined-outer-name
-    test,
-    config=None,
-    data=None,
-    launcher=None,
-    size=None,
-    **kwargs):
+def web_test(config=None, launcher=None, size=None, **kwargs):
   """Wrapper around web_test to correctly set defaults."""
   config = config or str(Label("//web:default_config"))
   launcher = launcher or str(Label("//go/wtl/main"))
-  data = lists.clone(data)
-  lists.ensure_contains_all(data, [browser, config, launcher, test])
   size = size or "large"
-  web_test_alias(
-      browser=browser,
-      config=config,
-      launcher=launcher,
-      test=test,
-      data=data,
-      size=size,
-      **kwargs)
+  web_test_alias(config=config, launcher=launcher, size=size, **kwargs)
 
 
-def web_test_config(**kwargs):
+def web_test_config(testonly=True, **kwargs):
   """Wrapper around web_test_config to correctly set defaults."""
-  web_test_config_alias(testonly=True, **kwargs)
+  web_test_config_alias(testonly=testonly, **kwargs)
 
 
-def web_test_named_executable(executable, data=None, **kwargs):
+def web_test_named_executable(testonly=True, **kwargs):
   """Wrapper around web_test_named_executable to correctly set defaults."""
-  data = lists.clone(data)
-  lists.ensure_contains(data, executable)
-  web_test_named_executable_alias(
-      data=data, executable=executable, testonly=True, **kwargs)
+  web_test_named_executable_alias(testonly=testonly, **kwargs)
 
 
-def web_test_named_file(**kwargs):
+def web_test_named_file(testonly=True, **kwargs):
   """Wrapper around web_test_named_file to correctly set defaults."""
-  web_test_named_file_alias(testonly=True, **kwargs)
+  web_test_named_file_alias(testonly=testonly, **kwargs)
 
 
-def web_test_archive(**kwargs):
+def web_test_archive(testonly=True, **kwargs):
   """Wrapper around web_test_archive to correctly set defaults."""
-  web_test_archive_alias(testonly=True, **kwargs)
+  web_test_archive_alias(testonly=testonly, **kwargs)
 
 
-def web_test_files(**kwargs):
+def web_test_files(testonly=True, **kwargs):
   """Wrapper around web_test_files to correctly set defaults."""
-  web_test_files_alias(testonly=True, **kwargs)
+  web_test_files_alias(testonly=testonly, **kwargs)


### PR DESCRIPTION
Improvements to runfiles handling.
Add doc parameters to rule and attr.* calls.
Remove data and deps from web_test_file and related rules.
Simplify macros.