### PR TITLE
Cleanup from Google3.

### DIFF
--- a/go/webtest/webtest.go
+++ b/go/webtest/webtest.go
@@ -31,6 +31,7 @@ package webtest
 
 import (
 	"errors"
+	"net/url"
 	"os"
 	"strings"
 
@@ -84,4 +85,26 @@ func NewWebDriverSession(capabilities selenium.Capabilities) (selenium.WebDriver
 	}
 
 	return selenium.NewRemote(capabilities, strings.TrimSuffix(address, "/"))
+}
+
+// HTTPAddress returns the HTTP address of WTL.
+func HTTPAddress() (*url.URL, error) {
+	address := os.Getenv("WEB_TEST_HTTP_SERVER")
+
+	if address == "" {
+		return nil, errors.New(`environment variable "WEB_TEST_HTTP_SERVER" not set`)
+	}
+
+	return url.Parse(address)
+}
+
+// HTTPSAddress returns the HTTPS address of WTL.
+func HTTPSAddress() (*url.URL, error) {
+	address := os.Getenv("WEB_TEST_HTTPS_SERVER")
+
+	if address == "" {
+		return nil, errors.New(`environment variable "WEB_TEST_HTTPS_SERVER" not set`)
+	}
+
+	return url.Parse(address)
 }

--- a/go/webtest/webtest_test.go
+++ b/go/webtest/webtest_test.go
@@ -15,6 +15,7 @@
 package webtest
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -27,7 +28,14 @@ func TestProvisionBrowser_NoCaps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := wd.Get("about:"); err != nil {
+	address, err := HTTPAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address = address.ResolveReference(&url.URL{Path: "/healthz"})
+
+	if err := wd.Get(address.String()); err != nil {
 		t.Error(err)
 	}
 
@@ -53,7 +61,14 @@ func TestProvisionBrowser_WithCaps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := wd.Get("about:"); err != nil {
+	address, err := HTTPAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address = address.ResolveReference(&url.URL{Path: "/healthz"})
+
+	if err := wd.Get(address.String()); err != nil {
 		t.Error(err)
 	}
 
@@ -94,6 +109,13 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestReusableBrowser(t *testing.T) {
+	address, err := HTTPAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address = address.ResolveReference(&url.URL{Path: "/healthz"})
+
 	wd1, err := NewWebDriverSession(selenium.Capabilities{
 		"google:canReuseSession": true,
 	})
@@ -117,7 +139,7 @@ func TestReusableBrowser(t *testing.T) {
 		t.Errorf("got different ids %q, %q, expected them to be the same.", id1, wd2.SessionID())
 	}
 
-	if err := wd2.Get("about:"); err != nil {
+	if err := wd2.Get(address.String()); err != nil {
 		t.Error(err)
 	}
 

--- a/java/com/google/testing/web/BUILD.bazel
+++ b/java/com/google/testing/web/BUILD.bazel
@@ -23,7 +23,6 @@ java_library(
     srcs = glob(["*.java"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@com_google_code_findbugs_jsr305",
         "@org_seleniumhq_selenium_api",
         "@org_seleniumhq_selenium_remote_driver",
     ],

--- a/java/com/google/testing/web/WebTest.java
+++ b/java/com/google/testing/web/WebTest.java
@@ -17,8 +17,10 @@
 package com.google.testing.web;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
-import javax.annotation.Nullable;
+import java.util.Optional;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
@@ -47,16 +49,27 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class WebTest {
 
-  @Nullable private final URL url;
+  private final URL wd;
+  private final URI http;
+  private final Optional<URI> https;
 
   public WebTest() {
-    this(System.getenv("WEB_TEST_WEBDRIVER_SERVER"));
+    this(
+        System.getenv("WEB_TEST_WEBDRIVER_SERVER"),
+        System.getenv("WEB_TEST_HTTP_SERVER"),
+        System.getenv("WEB_TEST_HTTPS_SERVER"));
   }
 
-  private WebTest(String address) {
+  private WebTest(String wd, String http, String https) {
     try {
-      this.url = new URL(address);
-    } catch (MalformedURLException e) {
+      this.wd = new URL(wd);
+      this.http = new URI(http);
+      if (https != null && !https.isEmpty()) {
+        this.https = Optional.of(new URI(https));
+      } else {
+        this.https = Optional.empty();
+      }
+    } catch (MalformedURLException | URISyntaxException e) {
       throw new RuntimeException(e);
     }
   }
@@ -72,8 +85,18 @@ public class WebTest {
    * @param capabilities Configuration of the browser.
    */
   public WebDriver newWebDriverSession(Capabilities capabilities) {
-    WebDriver driver = new Augmenter().augment(new RemoteWebDriver(url, capabilities));
+    WebDriver driver = new Augmenter().augment(new RemoteWebDriver(wd, capabilities));
 
     return driver;
+  }
+
+  /** Returns the HTTP address of WTL. */
+  public URI HTTPAddress() {
+    return http;
+  }
+
+  /** Returns the HTTPS address of WTL. */
+  public Optional<URI> HTTPSAddress() {
+    return https;
   }
 }

--- a/javatests/com/google/testing/web/WebTestTest.java
+++ b/javatests/com/google/testing/web/WebTestTest.java
@@ -26,7 +26,9 @@ public class WebTestTest {
 
   @Test
   public void newWebDriverSession() {
-    WebDriver driver = new WebTest().newWebDriverSession();
+    WebTest wt = new WebTest();
+    WebDriver driver = wt.newWebDriverSession();
+    driver.get(wt.HTTPAddress().resolve("/healthz").toString());
     driver.quit();
   }
 }

--- a/testing/web/webtest.py
+++ b/testing/web/webtest.py
@@ -46,3 +46,13 @@ def new_webdriver_session(capabilities={}):
   remote_connection.RemoteConnection.set_timeout(450)
 
   return webdriver.WebDriver(address, desired_capabilities=capabilities)
+
+
+def http_address():
+  """Return the HTTP address of WTL."""
+  return os.environ['WEB_TEST_HTTP_SERVER']
+
+
+def https_address():
+  """Return the HTTPS address of WTL."""
+  return os.environ['WEB_TEST_HTTPS_SERVER']

--- a/testing/web/webtest_test.py
+++ b/testing/web/webtest_test.py
@@ -24,7 +24,7 @@ class BrowserTest(unittest.TestCase):
     driver = webtest.new_webdriver_session()
 
     try:
-      driver.get("about:")
+      driver.get(webtest.http_address() + "/healthz")
       self.assertTrue(driver.current_url)
     finally:
       driver.quit()
@@ -37,7 +37,7 @@ class BrowserTest(unittest.TestCase):
     driver = webtest.new_webdriver_session(capabilities)
 
     try:
-      driver.get("about:")
+      driver.get(webtest.http_address() + "/healthz")
       self.assertTrue(driver.current_url)
     finally:
       driver.quit()

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -84,7 +84,7 @@ browser = rule(
         "required_tags":
             attr.string_list(
                 doc=
-                "A list of tags that  web_tests using this browser should have."
+                "A list of tags that web_tests using this browser should have."
             ),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},

--- a/web/internal/runfiles.bzl
+++ b/web/internal/runfiles.bzl
@@ -21,7 +21,7 @@ def _collect(ctx, files=[], targets=[]):
     ctx: Context object for the rule where this being used.
     files: a list of File object to include in the runfiles.
     targets: a list of Target object from which runfiles will be collected.
-  
+
   Returns:
     A configured runfiles object that include data and default runfiles for the
     rule, all transitive runfiles from targets, and all files from files.

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -174,7 +174,7 @@ web_test = rule(
                 mandatory=True),
         "web_test_template":
             attr.label(
-                doc="Shell template used to launch test when browser.",
+                doc="Shell template used to launch test.",
                 default=Label("//web/internal:web_test.sh.template"),
                 allow_single_file=True)
     },

--- a/web/internal/web_test_archive.bzl
+++ b/web/internal/web_test_archive.bzl
@@ -18,7 +18,6 @@ DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 
 load("//web/internal:metadata.bzl", "metadata")
 load("//web/internal:provider.bzl", "WebTestInfo")
-load("//web/internal:runfiles.bzl", "runfiles")
 
 
 def _web_test_archive_impl(ctx):
@@ -41,7 +40,7 @@ def _web_test_archive_impl(ctx):
 web_test_archive = rule(
     doc="""Specifies an archive file with named files in it.
 
-The archive will be unzipped only if Web Test Launcher wants one the named
+The archive will be unzipped only if Web Test Launcher wants one of the named
 files in the archive.""",
     implementation=_web_test_archive_impl,
     attrs={

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -40,7 +40,7 @@ def _web_test_named_executable_impl(ctx):
 
 
 web_test_named_executable = rule(
-    doc="Defines a executable that can be located by name.",
+    doc="Defines an executable that can be located by name.",
     attrs={
         "alt_name":
             attr.string(doc="If supplied, is used instead of name."),


### PR DESCRIPTION
- Skylark rule fixes.
- Add APIs to get WTL HTTP and HTTPS addresses.
- Use WTL healthz instead of about: for tests.