### PR TITLE
Minor cleanup

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -17,7 +17,10 @@
 load(":web.bzl", "web_test_config")
 load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
 
-package(default_testonly = True)
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -27,33 +30,11 @@ web_test_config(
 )
 
 skylark_library(
-    name = "repositories",
-    srcs = ["repositories.bzl"],
-    deps = ["//web/internal:platform_http_file"],
-)
-
-skylark_library(
-    name = "web",
-    srcs = ["web.bzl"],
-    visibility = ["//web/internal:__pkg__"],
-    deps = [
-        "//web/internal:browser",
-        "//web/internal:collections",
-        "//web/internal:constants",
-        "//web/internal:web_test",
-        "//web/internal:web_test_archive",
-        "//web/internal:web_test_config",
-        "//web/internal:web_test_named_executable",
-        "//web/internal:web_test_named_file",
-    ],
-)
-
-skylark_library(
     name = "go",
     srcs = ["go.bzl"],
     deps = [
         "//web/internal:wrap_web_test_suite",
-        # should depend on go build rules.
+        # should depend on Go build rules.
     ],
 )
 
@@ -70,10 +51,37 @@ skylark_library(
 )
 
 skylark_library(
+    name = "repositories",
+    srcs = ["repositories.bzl"],
+    deps = [
+        "//web/internal:java_import_external",
+        "//web/internal:platform_http_file",
+        "@bazel_skylib//:lib",
+        # should depend on Go build rules.
+    ],
+)
+
+skylark_library(
     name = "scala",
     srcs = ["scala.bzl"],
     deps = [
         "//web/internal:wrap_web_test_suite",
         # should depend on Scala build rules.
+    ],
+)
+
+skylark_library(
+    name = "web",
+    srcs = ["web.bzl"],
+    deps = [
+        "//web/internal:browser",
+        "//web/internal:collections",
+        "//web/internal:constants",
+        "//web/internal:web_test",
+        "//web/internal:web_test_archive",
+        "//web/internal:web_test_config",
+        "//web/internal:web_test_files",
+        "//web/internal:web_test_named_executable",
+        "//web/internal:web_test_named_file",
     ],
 )

--- a/web/internal/BUILD.bazel
+++ b/web/internal/BUILD.bazel
@@ -37,6 +37,7 @@ skylark_library(
     deps = [
         ":metadata",
         ":provider",
+        ":runfiles",
     ],
 )
 
@@ -53,7 +54,11 @@ skylark_library(
 skylark_library(
     name = "files",
     srcs = ["files.bzl"],
-    deps = [":collections"],
+)
+
+skylark_library(
+    name = "java_import_external",
+    srcs = ["java_import_external.bzl"],
 )
 
 skylark_library(
@@ -73,6 +78,11 @@ skylark_library(
 )
 
 skylark_library(
+    name = "runfiles",
+    srcs = ["runfiles.bzl"],
+)
+
+skylark_library(
     name = "web_test",
     srcs = ["web_test.bzl"],
     deps = [
@@ -80,6 +90,7 @@ skylark_library(
         ":files",
         ":metadata",
         ":provider",
+        ":runfiles",
     ],
 )
 
@@ -87,7 +98,7 @@ skylark_library(
     name = "web_test_archive",
     srcs = ["web_test_archive.bzl"],
     deps = [
-        ":files" +
+        ":files",
         ":metadata",
         ":provider",
         ":runfiles",
@@ -104,11 +115,21 @@ skylark_library(
 )
 
 skylark_library(
+    name = "web_test_files",
+    srcs = ["web_test_files.bzl"],
+    deps = [
+        ":metadata",
+        ":provider",
+    ],
+)
+
+skylark_library(
     name = "web_test_named_executable",
     srcs = ["web_test_named_executable.bzl"],
     deps = [
         ":metadata",
         ":provider",
+        ":runfiles",
     ],
 )
 

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -16,9 +16,9 @@
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:metadata.bzl", "metadata")
-load("//web/internal:provider.bzl", "WebTestInfo")
-load("//web/internal:runfiles.bzl", "runfiles")
+load(":metadata.bzl", "metadata")
+load(":provider.bzl", "WebTestInfo")
+load(":runfiles.bzl", "runfiles")
 
 
 def _browser_impl(ctx):

--- a/web/internal/files.bzl
+++ b/web/internal/files.bzl
@@ -13,8 +13,6 @@
 # limitations under the License.
 """A library of functions for working with runfiles."""
 
-load("//web/internal:collections.bzl", "lists")
-
 
 def _long_path(ctx, file):
   """Constructs a path relative to TEST_SRCDIR for accessing the file.

--- a/web/internal/metadata.bzl
+++ b/web/internal/metadata.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """A library of functions for working with web_test metadata files."""
 
-load("//web/internal:files.bzl", "files")
+load(":files.bzl", "files")
 
 
 def _merge_files(ctx, merger, output, inputs):

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -16,11 +16,11 @@
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:collections.bzl", "maps")
-load("//web/internal:files.bzl", "files")
-load("//web/internal:metadata.bzl", "metadata")
-load("//web/internal:provider.bzl", "WebTestInfo")
-load("//web/internal:runfiles.bzl", "runfiles")
+load(":collections.bzl", "maps")
+load(":files.bzl", "files")
+load(":metadata.bzl", "metadata")
+load(":provider.bzl", "WebTestInfo")
+load(":runfiles.bzl", "runfiles")
 
 
 def _web_test_impl(ctx):

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -19,8 +19,8 @@ such as additional capabilities.
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:metadata.bzl", "metadata")
-load("//web/internal:provider.bzl", "WebTestInfo")
+load(":metadata.bzl", "metadata")
+load(":provider.bzl", "WebTestInfo")
 
 
 def _web_test_config_impl(ctx):

--- a/web/internal/web_test_files.bzl
+++ b/web/internal/web_test_files.bzl
@@ -16,8 +16,8 @@
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:metadata.bzl", "metadata")
-load("//web/internal:provider.bzl", "WebTestInfo")
+load(":metadata.bzl", "metadata")
+load(":provider.bzl", "WebTestInfo")
 
 
 def _web_test_files_impl(ctx):

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -16,9 +16,9 @@
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:metadata.bzl", "metadata")
-load("//web/internal:provider.bzl", "WebTestInfo")
-load("//web/internal:runfiles.bzl", "runfiles")
+load(":metadata.bzl", "metadata")
+load(":provider.bzl", "WebTestInfo")
+load(":runfiles.bzl", "runfiles")
 
 
 def _web_test_named_executable_impl(ctx):

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -16,8 +16,8 @@
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:metadata.bzl", "metadata")
-load("//web/internal:provider.bzl", "WebTestInfo")
+load(":metadata.bzl", "metadata")
+load(":provider.bzl", "WebTestInfo")
 
 
 def _web_test_named_file_impl(ctx):

--- a/web/internal/wrap_web_test_suite.bzl
+++ b/web/internal/wrap_web_test_suite.bzl
@@ -14,7 +14,7 @@
 """Definition of wrap_web_test_suite."""
 
 load("//web:web.bzl", "web_test_suite")
-load("//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
+load(":constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
 
 
 def wrap_web_test_suite(name,

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -13,29 +13,23 @@
 # limitations under the License.
 """Public definitions for web_test related build rules."""
 
+load("//web/internal:browser.bzl", browser_alias="browser")
 load("//web/internal:collections.bzl", "lists", "maps")
-load(
-    "//web/internal:browser.bzl",
-    browser_alias="browser",
-)
 load("//web/internal:constants.bzl", "DEFAULT_TEST_SUITE_TAGS")
+load("//web/internal:web_test.bzl", web_test_alias="web_test")
 load(
-    "//web/internal:web_test.bzl",
-    web_test_alias="web_test",
-)
+    "//web/internal:web_test_archive.bzl",
+    web_test_archive_alias="web_test_archive")
 load(
     "//web/internal:web_test_config.bzl",
     web_test_config_alias="web_test_config")
+load("//web/internal:web_test_files.bzl", web_test_files_alias="web_test_files")
 load(
     "//web/internal:web_test_named_executable.bzl",
     web_test_named_executable_alias="web_test_named_executable")
 load(
     "//web/internal:web_test_named_file.bzl",
     web_test_named_file_alias="web_test_named_file")
-load(
-    "//web/internal:web_test_archive.bzl",
-    web_test_archive_alias="web_test_archive")
-load("//web/internal:web_test_files.bzl", web_test_files_alias="web_test_files")
 
 
 def web_test_suite(name,


### PR DESCRIPTION
- Use relative labels for load when possible.
- Ensure that all .bzl files have correct library rules.