### PR TITLE
Remove error return from ToMixedMode.

### DIFF
--- a/go/metadata/capabilities/capabilities.go
+++ b/go/metadata/capabilities/capabilities.go
@@ -275,20 +275,22 @@ func w3cCapabilities(in map[string]interface{}) map[string]interface{} {
 }
 
 // ToMixedMode creates a map suitable for use as arguments to a New Session request for arbitrary remote ends.
-// Since JWP does not support an equivalent to FirstMatch, if FirstMatch contains more than 1 entry
-// then this returns an error (if it contains exactly 1 entry, it will be merged over AlwaysMatch).
-// If W3CSupported is false, this will return JWP capabilities instead of mixed-mode.
-func (c *Capabilities) ToMixedMode() (map[string]interface{}, error) {
+// If FirstMatch contains more than 1 entry then this returns W3C-only capabilities.
+// If W3CSupported is false then this will return JWP-only capabilities.
+func (c *Capabilities) ToMixedMode() map[string]interface{} {
 	if c == nil {
 		return map[string]interface{}{
 			"capabilities":        map[string]interface{}{},
 			"desiredCapabilities": map[string]interface{}{},
-		}, nil
+		}
 	}
 
 	jwp, err := c.ToJWP()
-	if err != nil || c.W3CSupported {
-		return jwp, err
+	if err != nil {
+		return c.ToW3C()
+	}
+	if !c.W3CSupported {
+		return jwp
 	}
 
 	w3c := c.ToW3C()
@@ -296,7 +298,7 @@ func (c *Capabilities) ToMixedMode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"capabilities":        w3c["capabilities"],
 		"desiredCapabilities": jwp["desiredCapabilities"],
-	}, nil
+	}
 }
 
 // Merge takes two JSON objects, and merges them.

--- a/go/webdriver/webdriver.go
+++ b/go/webdriver/webdriver.go
@@ -166,11 +166,7 @@ func (j *jsonResp) isError() bool {
 // CreateSession creates a new WebDriver session with desired capabilities from server at addr
 // and ensures that the browser connection is working. It retries up to attempts - 1 times.
 func CreateSession(ctx context.Context, addr string, attempts int, requestedCaps *capabilities.Capabilities) (WebDriver, error) {
-	reqBody, err := requestedCaps.ToMixedMode()
-	if err != nil {
-		log.Print("Creating session with W3C-only capabilities")
-		reqBody = requestedCaps.ToW3C()
-	}
+	reqBody := requestedCaps.ToMixedMode()
 
 	urlPrefix, err := url.Parse(addr)
 	if err != nil {


### PR DESCRIPTION
Under certain conditions, ToMixedMode will return JWP-only or W3C-only
capabilities.