### PR TITLE
Add local_hostname flag.

### DIFF
--- a/go/httphelper/http_helper.go
+++ b/go/httphelper/http_helper.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 )
 
 var client = &http.Client{
@@ -34,6 +35,16 @@ var client = &http.Client{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	},
 }
 

--- a/go/wsl/driver/driver.go
+++ b/go/wsl/driver/driver.go
@@ -22,9 +22,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -51,7 +53,7 @@ type Driver struct {
 
 // New creates starts a WebDriver endpoint binary based on caps. Argument caps should just be
 // the google:wslConfig capability extracted from the capabilities passed into a new session request.
-func New(ctx context.Context, caps map[string]interface{}) (*Driver, error) {
+func New(ctx context.Context, localHostname string, caps map[string]interface{}) (*Driver, error) {
 	wslCaps, err := extractWSLCaps(caps)
 	if err != nil {
 		return nil, err
@@ -94,7 +96,9 @@ func New(ctx context.Context, caps map[string]interface{}) (*Driver, error) {
 	deadline, cancel := context.WithTimeout(ctx, wslCaps.timeout)
 	defer cancel()
 
-	statusURL := fmt.Sprintf("http://localhost:%d/status", wslCaps.port)
+	hostPort := net.JoinHostPort(localHostname, strconv.Itoa(wslCaps.port))
+
+	statusURL := fmt.Sprintf("http://%s/status", hostPort)
 
 	errChan := make(chan error, 1)
 	driverChan := make(chan error, 1)
@@ -149,7 +153,7 @@ func New(ctx context.Context, caps map[string]interface{}) (*Driver, error) {
 	}
 
 	return &Driver{
-		Address:  fmt.Sprintf("http://localhost:%d", wslCaps.port),
+		Address:  fmt.Sprintf("http://%s", hostPort),
 		cmd:      cmd,
 		waitChan: driverChan,
 	}, nil

--- a/go/wsl/driver/driver.go
+++ b/go/wsl/driver/driver.go
@@ -53,7 +53,7 @@ type Driver struct {
 
 // New creates starts a WebDriver endpoint binary based on caps. Argument caps should just be
 // the google:wslConfig capability extracted from the capabilities passed into a new session request.
-func New(ctx context.Context, localHostname string, caps map[string]interface{}) (*Driver, error) {
+func New(ctx context.Context, localHost string, caps map[string]interface{}) (*Driver, error) {
 	wslCaps, err := extractWSLCaps(caps)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func New(ctx context.Context, localHostname string, caps map[string]interface{})
 	deadline, cancel := context.WithTimeout(ctx, wslCaps.timeout)
 	defer cancel()
 
-	hostPort := net.JoinHostPort(localHostname, strconv.Itoa(wslCaps.port))
+	hostPort := net.JoinHostPort(localHost, strconv.Itoa(wslCaps.port))
 
 	statusURL := fmt.Sprintf("http://%s/status", hostPort)
 

--- a/go/wsl/hub/hub.go
+++ b/go/wsl/hub/hub.go
@@ -36,15 +36,15 @@ type Hub struct {
 	mu       sync.RWMutex
 	sessions map[string]*driver.Driver
 
-	localHostname string
+	localHost string
 	uploader      http.Handler
 }
 
 // New creates a new Hub.
-func New(localHostname string, uploader http.Handler) *Hub {
+func New(localHost string, uploader http.Handler) *Hub {
 	return &Hub{
 		sessions:      map[string]*driver.Driver{},
-		localHostname: localHostname,
+		localHost: localHost,
 		uploader:      uploader,
 	}
 }
@@ -122,7 +122,7 @@ func (h *Hub) newSessionFromCaps(ctx context.Context, caps *capabilities.Capabil
 	if caps.AlwaysMatch != nil {
 		wslConfig, ok := caps.AlwaysMatch["google:wslConfig"].(map[string]interface{})
 		if ok {
-			d, err := driver.New(ctx, h.localHostname, wslConfig)
+			d, err := driver.New(ctx, h.localHost, wslConfig)
 			if err != nil {
 				return "", nil, err
 			}
@@ -141,7 +141,7 @@ func (h *Hub) newSessionFromCaps(ctx context.Context, caps *capabilities.Capabil
 		wslConfig, ok := fm["google:wslConfig"].(map[string]interface{})
 
 		if ok {
-			d, err := driver.New(ctx, h.localHostname, wslConfig)
+			d, err := driver.New(ctx, h.localHost, wslConfig)
 			if err != nil {
 				continue
 			}

--- a/go/wsl/hub/hub.go
+++ b/go/wsl/hub/hub.go
@@ -36,14 +36,16 @@ type Hub struct {
 	mu       sync.RWMutex
 	sessions map[string]*driver.Driver
 
-	uploader http.Handler
+	localHostname string
+	uploader      http.Handler
 }
 
 // New creates a new Hub.
-func New(uploader http.Handler) *Hub {
+func New(localHostname string, uploader http.Handler) *Hub {
 	return &Hub{
-		sessions: map[string]*driver.Driver{},
-		uploader: uploader,
+		sessions:      map[string]*driver.Driver{},
+		localHostname: localHostname,
+		uploader:      uploader,
 	}
 }
 
@@ -120,7 +122,7 @@ func (h *Hub) newSessionFromCaps(ctx context.Context, caps *capabilities.Capabil
 	if caps.AlwaysMatch != nil {
 		wslConfig, ok := caps.AlwaysMatch["google:wslConfig"].(map[string]interface{})
 		if ok {
-			d, err := driver.New(ctx, wslConfig)
+			d, err := driver.New(ctx, h.localHostname, wslConfig)
 			if err != nil {
 				return "", nil, err
 			}
@@ -139,7 +141,7 @@ func (h *Hub) newSessionFromCaps(ctx context.Context, caps *capabilities.Capabil
 		wslConfig, ok := fm["google:wslConfig"].(map[string]interface{})
 
 		if ok {
-			d, err := driver.New(ctx, wslConfig)
+			d, err := driver.New(ctx, h.localHostname, wslConfig)
 			if err != nil {
 				continue
 			}

--- a/go/wsl/main/main.go
+++ b/go/wsl/main/main.go
@@ -28,7 +28,7 @@ var (
 	downloadRoot  = flag.String("download_root", "", "Directory served at /google/staticfile/.")
 	uploadRoot    = flag.String("upload_root", "", "Directory to which files sent to /session/<id>/upload will be uploaded.")
 	logFile       = flag.String("log_file", "", "File for WSL logs.")
-	localHostname = flag.String("local_hostname", "localhost", "Name to use for localhost.")
+	localHost = flag.String("local_host", "localhost", "Name to use for localhost.")
 )
 
 func main() {
@@ -44,5 +44,5 @@ func main() {
 	}
 
 	log.SetFlags(log.Flags() | log.Lmicroseconds)
-	wsl.Run(*localHostname, *port, *downloadRoot, *uploadRoot)
+	wsl.Run(*localHost, *port, *downloadRoot, *uploadRoot)
 }

--- a/go/wsl/main/main.go
+++ b/go/wsl/main/main.go
@@ -24,10 +24,11 @@ import (
 )
 
 var (
-	port         = flag.Int("port", 4444, "Port to start WSL on.")
-	downloadRoot = flag.String("download_root", "", "Directory served at /google/staticfile/.")
-	uploadRoot   = flag.String("upload_root", "", "Directory to which files sent to /session/<id>/upload will be uploaded.")
-	logFile      = flag.String("log_file", "", "File for WSL logs.")
+	port          = flag.Int("port", 4444, "Port to start WSL on.")
+	downloadRoot  = flag.String("download_root", "", "Directory served at /google/staticfile/.")
+	uploadRoot    = flag.String("upload_root", "", "Directory to which files sent to /session/<id>/upload will be uploaded.")
+	logFile       = flag.String("log_file", "", "File for WSL logs.")
+	localHostname = flag.String("local_hostname", "localhost", "Name to use for localhost.")
 )
 
 func main() {
@@ -42,5 +43,6 @@ func main() {
 		log.SetOutput(out)
 	}
 
-	wsl.Run(*port, *downloadRoot, *uploadRoot)
+	log.SetFlags(log.Flags() | log.Lmicroseconds)
+	wsl.Run(*localHostname, *port, *downloadRoot, *uploadRoot)
 }

--- a/go/wsl/wsl.go
+++ b/go/wsl/wsl.go
@@ -28,11 +28,11 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/wsl/upload"
 )
 
-func Run(port int, downloadRoot, uploadRoot string) {
+func Run(localHostname string, port int, downloadRoot, uploadRoot string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	handler := createHandler(hub.New(&upload.Uploader{Root: uploadRoot}), downloadRoot, cancel)
+	handler := createHandler(hub.New(localHostname, &upload.Uploader{Root: uploadRoot}), downloadRoot, cancel)
 
 	if err := startServer(ctx, port, handler); err != nil {
 		log.Print(err)

--- a/go/wsl/wsl.go
+++ b/go/wsl/wsl.go
@@ -28,11 +28,11 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/wsl/upload"
 )
 
-func Run(localHostname string, port int, downloadRoot, uploadRoot string) {
+func Run(localHost string, port int, downloadRoot, uploadRoot string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	handler := createHandler(hub.New(localHostname, &upload.Uploader{Root: uploadRoot}), downloadRoot, cancel)
+	handler := createHandler(hub.New(localHost, &upload.Uploader{Root: uploadRoot}), downloadRoot, cancel)
 
 	if err := startServer(ctx, port, handler); err != nil {
 		log.Print(err)


### PR DESCRIPTION
- This allows specifying what name to use for localhost (localhost,
  127.0.0.1, ::1, ...) for making connections to the launched drivers.
- Configure transport in httphelper to be closer to
  http.DefaultTransport.