### PR TITLE
Use buildifier to format .bzl files.

### DIFF
--- a/web/go.bzl
+++ b/web/go.bzl
@@ -16,7 +16,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("//web/internal:wrap_web_test_suite.bzl", "wrap_web_test_suite")
 
-
 def go_web_test_suite(name, go_test_tags=None, glaze_kind=None, **kwargs):
   """Defines a test_suite of web_test targets that wrap a go_test target.
 

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -20,7 +20,6 @@ load(":metadata.bzl", "metadata")
 load(":provider.bzl", "WebTestInfo")
 load(":runfiles.bzl", "runfiles")
 
-
 def _browser_impl(ctx):
   """Implementation of the browser rule."""
   patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
@@ -46,46 +45,43 @@ def _browser_impl(ctx):
           required_tags=ctx.attr.required_tags),
   ]
 
-
 browser = rule(
-    doc="Defines a browser configuration for use with web_test.",
-    attrs={
-        "data":
-            attr.label_list(
-                doc="Runtime dependencies for this configuration.",
-                allow_files=True,
-                cfg="data"),
-        "deps":
-            attr.label_list(
-                doc="Other web_test-related rules that this rule depends on.",
-                providers=[WebTestInfo]),
-        "disabled":
-            attr.string(
-                doc=
-                "If set then a no-op test will be run when using this browser."
-            ),
-        "environment":
-            attr.string_dict(doc="Map of environment variables-values to set."),
-        "execution_requirements":
-            attr.string_dict(
-                doc="Map of execution requirements for this browser."),
-        "merger":
-            attr.label(
-                doc="Metadata merger executable.",
-                default=Label("//go/metadata/main"),
-                executable=True,
-                cfg="host"),
-        "metadata":
-            attr.label(
-                doc="The web_test metadata file that defines how this browser is "
-                + "launched and default capabilities for this browser.",
-                mandatory=True,
-                allow_single_file=[".json"]),
-        "required_tags":
-            attr.string_list(
-                doc=
-                "A list of tags that web_tests using this browser should have."
-            ),
+    attrs = {
+        "data": attr.label_list(
+            doc = "Runtime dependencies for this configuration.",
+            allow_files = True,
+            cfg = "data",
+        ),
+        "deps": attr.label_list(
+            doc = "Other web_test-related rules that this rule depends on.",
+            providers = [WebTestInfo],
+        ),
+        "disabled": attr.string(
+            doc =
+                "If set then a no-op test will be run when using this browser.",
+        ),
+        "environment": attr.string_dict(doc = "Map of environment variables-values to set."),
+        "execution_requirements": attr.string_dict(
+            doc = "Map of execution requirements for this browser.",
+        ),
+        "merger": attr.label(
+            doc = "Metadata merger executable.",
+            default = Label("//go/metadata/main"),
+            executable = True,
+            cfg = "host",
+        ),
+        "metadata": attr.label(
+            doc = "The web_test metadata file that defines how this browser is " +
+                  "launched and default capabilities for this browser.",
+            mandatory = True,
+            allow_single_file = [".json"],
+        ),
+        "required_tags": attr.string_list(
+            doc =
+                "A list of tags that web_tests using this browser should have.",
+        ),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_browser_impl)
+    doc = "Defines a browser configuration for use with web_test.",
+    outputs = {"web_test_metadata": "%{name}.gen.json"},
+    implementation = _browser_impl,
+)

--- a/web/internal/collections.bzl
+++ b/web/internal/collections.bzl
@@ -20,23 +20,19 @@ Usage:
   lists.ensure_contains(l, "//some:target")
 """
 
-
 def _is_list_like(val):
   """Checks is val is a list-like (list, depset, tuple) value."""
   return type(val) in [type([]), type(depset()), type(())]
-
 
 def _list_ensure_contains(lst, item):
   """Appends the specified item to the list if its not already a member."""
   if item not in lst:
     lst.append(item)
 
-
 def _list_ensure_contains_all(lst, items):
   """Appends the specified items to the list if not already members."""
   for item in items:
     _list_ensure_contains(lst, item)
-
 
 def _list_clone(original):
   """Create a new list with content of original."""
@@ -46,13 +42,12 @@ def _list_clone(original):
     fail('got "' + original + '", but expected none or a list-like value')
   return []
 
-
 lists = struct(
-    clone=_list_clone,
-    ensure_contains=_list_ensure_contains,
-    ensure_contains_all=_list_ensure_contains_all,
-    is_list_like=_is_list_like)
-
+    clone = _list_clone,
+    ensure_contains = _list_ensure_contains,
+    ensure_contains_all = _list_ensure_contains_all,
+    is_list_like = _is_list_like,
+)
 
 def _map_clone(original):
   new_map = {}
@@ -60,5 +55,4 @@ def _map_clone(original):
     new_map.update(original)
   return new_map
 
-
-maps = struct(clone=_map_clone)
+maps = struct(clone = _map_clone)

--- a/web/internal/files.bzl
+++ b/web/internal/files.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 """A library of functions for working with runfiles."""
 
-
 def _long_path(ctx, file):
   """Constructs a path relative to TEST_SRCDIR for accessing the file.
 
@@ -36,5 +35,4 @@ def _long_path(ctx, file):
   # otherwise assume the file is in the same workspace as the current rule.
   return ctx.workspace_name + "/" + file.short_path
 
-
-files = struct(long_path=_long_path)
+files = struct(long_path = _long_path)

--- a/web/internal/java_import_external.bzl
+++ b/web/internal/java_import_external.bzl
@@ -21,7 +21,6 @@ _PASS_PROPS = (
     "deps",
 )
 
-
 def _java_import_external(repository_ctx):
   """Downloads jar and creates a java_import rule."""
   if (repository_ctx.attr.generated_linkable_rule_name and
@@ -67,7 +66,6 @@ def _java_import_external(repository_ctx):
     repository_ctx.download(srcurls, srcpath, srcsha)
   repository_ctx.file("BUILD", "\n".join(lines))
 
-
 def _make_java_import(name, path, srcpath, attrs, props):
   lines = [
       "java_import(",
@@ -86,36 +84,28 @@ def _make_java_import(name, path, srcpath, attrs, props):
   lines.append("")
   return lines
 
-
 java_import_external = repository_rule(
-    implementation=_java_import_external,
-    attrs={
-        "licenses":
-            attr.string_list(mandatory=True, allow_empty=False),
-        "jar_urls":
-            attr.string_list(mandatory=True, allow_empty=False),
-        "jar_sha256":
-            attr.string(mandatory=True),
-        "srcjar_urls":
-            attr.string_list(),
-        "srcjar_sha256":
-            attr.string(),
-        "deps":
-            attr.string_list(),
-        "runtime_deps":
-            attr.string_list(),
-        "testonly_":
-            attr.bool(),
-        "exports":
-            attr.string_list(),
-        "neverlink":
-            attr.bool(),
-        "generated_rule_name":
-            attr.string(),
-        "generated_linkable_rule_name":
-            attr.string(),
-        "default_visibility":
-            attr.string_list(default=["//visibility:public"]),
-        "extra_build_file_content":
-            attr.string(),
-    })
+    attrs = {
+        "licenses": attr.string_list(
+            mandatory = True,
+            allow_empty = False,
+        ),
+        "jar_urls": attr.string_list(
+            mandatory = True,
+            allow_empty = False,
+        ),
+        "jar_sha256": attr.string(mandatory = True),
+        "srcjar_urls": attr.string_list(),
+        "srcjar_sha256": attr.string(),
+        "deps": attr.string_list(),
+        "runtime_deps": attr.string_list(),
+        "testonly_": attr.bool(),
+        "exports": attr.string_list(),
+        "neverlink": attr.bool(),
+        "generated_rule_name": attr.string(),
+        "generated_linkable_rule_name": attr.string(),
+        "default_visibility": attr.string_list(default = ["//visibility:public"]),
+        "extra_build_file_content": attr.string(),
+    },
+    implementation = _java_import_external,
+)

--- a/web/internal/metadata.bzl
+++ b/web/internal/metadata.bzl
@@ -15,7 +15,6 @@
 
 load(":files.bzl", "files")
 
-
 def _merge_files(ctx, merger, output, inputs):
   """Produces a merged web test metadata file.
 
@@ -38,7 +37,6 @@ def _merge_files(ctx, merger, output, inputs):
       arguments=args,
       mnemonic="METADATAMERGER",
       progress_message="merging %s" % (", ".join(short_paths)))
-
 
 def _create_file(ctx,
                  output,
@@ -86,7 +84,6 @@ def _create_file(ctx,
   ctx.file_action(
       output=output, content=struct(**fields).to_json(), executable=False)
 
-
 def _web_test_files(ctx, archive_file=None, named_files=None, strip_prefix=""):
   """Build a web_test_files struct.
 
@@ -113,8 +110,8 @@ def _web_test_files(ctx, archive_file=None, named_files=None, strip_prefix=""):
       namedFiles=struct(**named_files),
       stripPrefix=strip_prefix)
 
-
 metadata = struct(
-    create_file=_create_file,
-    merge_files=_merge_files,
-    web_test_files=_web_test_files)
+    create_file = _create_file,
+    merge_files = _merge_files,
+    web_test_files = _web_test_files,
+)

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Downloads files based on local platform."""
 
-
 def _impl(repository_ctx):
   if repository_ctx.os.name.lower().startswith("mac os"):
     urls = repository_ctx.attr.macos_urls
@@ -38,14 +37,14 @@ def _impl(repository_ctx):
           ")",
       ]))
 
-
 platform_http_file = repository_rule(
-    implementation=_impl,
-    attrs={
+    attrs = {
         "amd64_urls": attr.string_list(),
         "amd64_sha256": attr.string(),
         "macos_urls": attr.string_list(),
         "macos_sha256": attr.string(),
         "windows_urls": attr.string_list(),
         "windows_sha256": attr.string(),
-    })
+    },
+    implementation = _impl,
+)

--- a/web/internal/provider.bzl
+++ b/web/internal/provider.bzl
@@ -14,9 +14,12 @@
 """Definition of WebTestInfo provider."""
 
 WebTestInfo = provider(
-    doc="Provider for web_test information",
-    fields=[
-        "disabled", "environment", "execution_requirements", "metadata",
-        "required_tags"
+    doc = "Provider for web_test information",
+    fields = [
+        "disabled",
+        "environment",
+        "execution_requirements",
+        "metadata",
+        "required_tags",
     ],
 )

--- a/web/internal/runfiles.bzl
+++ b/web/internal/runfiles.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Runfiles modules contains utility functions for working with runfiles."""
 
-
 def _collect(ctx, files=[], targets=[]):
   """Builds a runfiles object with transitive files from all targets.
 
@@ -56,5 +55,4 @@ def _collect(ctx, files=[], targets=[]):
 
   return result
 
-
-runfiles = struct(collect=_collect,)
+runfiles = struct(collect = _collect)

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -22,7 +22,6 @@ load(":metadata.bzl", "metadata")
 load(":provider.bzl", "WebTestInfo")
 load(":runfiles.bzl", "runfiles")
 
-
 def _web_test_impl(ctx):
   if ctx.attr.browser[WebTestInfo].disabled:
     return _generate_noop_test(
@@ -43,7 +42,6 @@ Why was this browser disabled?
         browser=ctx.attr.browser.label, tags=missing_tags))
 
   return _generate_default_test(ctx)
-
 
 def _generate_noop_test(ctx, reason, status=0):
   """Generates a no-op test.
@@ -73,7 +71,6 @@ def _generate_noop_test(ctx, reason, status=0):
       executable=True)
 
   return []
-
 
 def _generate_default_test(ctx):
   patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
@@ -130,56 +127,56 @@ def _generate_default_test(ctx):
       testing.TestEnvironment(ctx.attr.browser[WebTestInfo].environment),
   ]
 
-
 web_test = rule(
-    doc="Runs a provided test against a provided browser configuration.",
-    attrs={
-        "browser":
-            attr.label(
-                doc="The browser configuration to use for this test.",
-                mandatory=True,
-                providers=[WebTestInfo]),
-        "config":
-            attr.label(
-                doc="Additional configuration for this test.",
-                mandatory=True,
-                providers=[WebTestInfo]),
-        "data":
-            attr.label_list(
-                doc="Additional runtime dependencies for the test.",
-                allow_files=True,
-                cfg="data"),
-        "launcher":
-            attr.label(
-                doc="The web test launcher binary.",
-                cfg="target",
-                executable=True),
-        "merger":
-            attr.label(
-                doc="The metadata merger binary.",
-                default=Label("//go/metadata/main"),
-                cfg="host",
-                executable=True),
-        "noop_web_test_template":
-            attr.label(
-                doc=
+    attrs = {
+        "browser": attr.label(
+            doc = "The browser configuration to use for this test.",
+            mandatory = True,
+            providers = [WebTestInfo],
+        ),
+        "config": attr.label(
+            doc = "Additional configuration for this test.",
+            mandatory = True,
+            providers = [WebTestInfo],
+        ),
+        "data": attr.label_list(
+            doc = "Additional runtime dependencies for the test.",
+            allow_files = True,
+            cfg = "data",
+        ),
+        "launcher": attr.label(
+            doc = "The web test launcher binary.",
+            cfg = "target",
+            executable = True,
+        ),
+        "merger": attr.label(
+            doc = "The metadata merger binary.",
+            default = Label("//go/metadata/main"),
+            cfg = "host",
+            executable = True,
+        ),
+        "noop_web_test_template": attr.label(
+            doc =
                 "Shell template used to launch test when browser is disabled.",
-                default=Label("//web/internal:noop_web_test.sh.template"),
-                allow_single_file=True),
-        "test":
-            attr.label(
-                doc="The test that will be run against the provided browser.",
-                cfg="target",
-                executable=True,
-                mandatory=True),
-        "web_test_template":
-            attr.label(
-                doc="Shell template used to launch test.",
-                default=Label("//web/internal:web_test.sh.template"),
-                allow_single_file=True)
+            default = Label("//web/internal:noop_web_test.sh.template"),
+            allow_single_file = True,
+        ),
+        "test": attr.label(
+            doc = "The test that will be run against the provided browser.",
+            cfg = "target",
+            executable = True,
+            mandatory = True,
+        ),
+        "web_test_template": attr.label(
+            doc = "Shell template used to launch test.",
+            default = Label("//web/internal:web_test.sh.template"),
+            allow_single_file = True,
+        ),
     },
-    outputs={
+    doc = "Runs a provided test against a provided browser configuration.",
+    outputs = {
         "web_test_metadata": "%{name}.gen.json",
     },
-    test=True,
-    implementation=_web_test_impl)
+    test = True,
+    implementation = _web_test_impl,
+)

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -22,7 +22,6 @@ DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 load(":metadata.bzl", "metadata")
 load(":provider.bzl", "WebTestInfo")
 
-
 def _web_test_config_impl(ctx):
   """Implementation of the web_test_config rule."""
   metadata_files = []
@@ -47,28 +46,29 @@ def _web_test_config_impl(ctx):
       WebTestInfo(metadata=ctx.outputs.web_test_metadata),
   ]
 
-
 web_test_config = rule(
-    doc="A configuration that can be used across multiple web_tests.",
-    attrs={
-        "data":
-            attr.label_list(
-                doc="Runtime dependencies for this configuration.",
-                allow_files=True,
-                cfg="data"),
-        "deps":
-            attr.label_list(
-                doc="Other web_test-related rules that this rule depends on.",
-                providers=[WebTestInfo]),
-        "merger":
-            attr.label(
-                doc="Metadata merger executable.",
-                executable=True,
-                cfg="host",
-                default=Label("//go/metadata/main")),
-        "metadata":
-            attr.label(
-                doc="A web_test metadata file.", allow_single_file=[".json"]),
+    attrs = {
+        "data": attr.label_list(
+            doc = "Runtime dependencies for this configuration.",
+            allow_files = True,
+            cfg = "data",
+        ),
+        "deps": attr.label_list(
+            doc = "Other web_test-related rules that this rule depends on.",
+            providers = [WebTestInfo],
+        ),
+        "merger": attr.label(
+            doc = "Metadata merger executable.",
+            executable = True,
+            cfg = "host",
+            default = Label("//go/metadata/main"),
+        ),
+        "metadata": attr.label(
+            doc = "A web_test metadata file.",
+            allow_single_file = [".json"],
+        ),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_web_test_config_impl)
+    doc = "A configuration that can be used across multiple web_tests.",
+    outputs = {"web_test_metadata": "%{name}.gen.json"},
+    implementation = _web_test_config_impl,
+)

--- a/web/internal/web_test_files.bzl
+++ b/web/internal/web_test_files.bzl
@@ -19,7 +19,6 @@ DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 load(":metadata.bzl", "metadata")
 load(":provider.bzl", "WebTestInfo")
 
-
 def _web_test_files_impl(ctx):
   named_files = {}
   runfiles = depset()
@@ -47,23 +46,22 @@ def _web_test_files_impl(ctx):
       WebTestInfo(metadata=ctx.outputs.web_test_metadata),
   ]
 
-
 web_test_files = rule(
-    doc="Specifies a set of named files.",
-    implementation=_web_test_files_impl,
-    attrs={
-        "merger":
-            attr.label(
-                doc="Metadata merger executable.",
-                executable=True,
-                cfg="host",
-                default=Label("//go/metadata/main")),
-        "files":
-            attr.label_keyed_string_dict(
-                doc="A map of files to names.",
-                mandatory=True,
-                allow_files=True,
-                allow_empty=False),
+    attrs = {
+        "merger": attr.label(
+            doc = "Metadata merger executable.",
+            executable = True,
+            cfg = "host",
+            default = Label("//go/metadata/main"),
+        ),
+        "files": attr.label_keyed_string_dict(
+            doc = "A map of files to names.",
+            mandatory = True,
+            allow_files = True,
+            allow_empty = False,
+        ),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},
+    doc = "Specifies a set of named files.",
+    outputs = {"web_test_metadata": "%{name}.gen.json"},
+    implementation = _web_test_files_impl,
 )

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -20,7 +20,6 @@ load(":metadata.bzl", "metadata")
 load(":provider.bzl", "WebTestInfo")
 load(":runfiles.bzl", "runfiles")
 
-
 def _web_test_named_executable_impl(ctx):
   name = ctx.attr.alt_name or ctx.label.name
 
@@ -38,26 +37,24 @@ def _web_test_named_executable_impl(ctx):
       WebTestInfo(metadata=ctx.outputs.web_test_metadata),
   ]
 
-
 web_test_named_executable = rule(
-    doc="Defines an executable that can be located by name.",
-    attrs={
-        "alt_name":
-            attr.string(doc="If supplied, is used instead of name."),
-        "executable":
-            attr.label(
-                doc="The executable that will be returned for name.",
-                allow_files=True,
-                executable=True,
-                cfg="target",
-                mandatory=True),
-        "merger":
-            attr.label(
-                doc="Metadata merger executable.",
-                executable=True,
-                cfg="host",
-                default=Label("//go/metadata/main")),
+    attrs = {
+        "alt_name": attr.string(doc = "If supplied, is used instead of name."),
+        "executable": attr.label(
+            doc = "The executable that will be returned for name.",
+            allow_files = True,
+            executable = True,
+            cfg = "target",
+            mandatory = True,
+        ),
+        "merger": attr.label(
+            doc = "Metadata merger executable.",
+            executable = True,
+            cfg = "host",
+            default = Label("//go/metadata/main"),
+        ),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_web_test_named_executable_impl,
+    doc = "Defines an executable that can be located by name.",
+    outputs = {"web_test_metadata": "%{name}.gen.json"},
+    implementation = _web_test_named_executable_impl,
 )

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -19,7 +19,6 @@ DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 load(":metadata.bzl", "metadata")
 load(":provider.bzl", "WebTestInfo")
 
-
 def _web_test_named_file_impl(ctx):
   name = ctx.attr.alt_name or ctx.label.name
 
@@ -37,17 +36,16 @@ def _web_test_named_file_impl(ctx):
       WebTestInfo(metadata=ctx.outputs.web_test_metadata),
   ]
 
-
 web_test_named_file = rule(
-    doc="Defines a file that can be located by name.",
-    attrs={
-        "alt_name":
-            attr.string(doc="If supplied, is used instead of name."),
-        "file":
-            attr.label(
-                doc="The file that will be returned for name.",
-                allow_single_file=True,
-                mandatory=True),
+    attrs = {
+        "alt_name": attr.string(doc = "If supplied, is used instead of name."),
+        "file": attr.label(
+            doc = "The file that will be returned for name.",
+            allow_single_file = True,
+            mandatory = True,
+        ),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_web_test_named_file_impl)
+    doc = "Defines a file that can be located by name.",
+    outputs = {"web_test_metadata": "%{name}.gen.json"},
+    implementation = _web_test_named_file_impl,
+)

--- a/web/internal/wrap_web_test_suite.bzl
+++ b/web/internal/wrap_web_test_suite.bzl
@@ -16,7 +16,6 @@
 load("//web:web.bzl", "web_test_suite")
 load(":constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
 
-
 def wrap_web_test_suite(name,
                         browsers,
                         rule,

--- a/web/java.bzl
+++ b/web/java.bzl
@@ -15,7 +15,6 @@
 
 load("//web/internal:wrap_web_test_suite.bzl", "wrap_web_test_suite")
 
-
 def java_web_test_suite(name, java_test_tags=None, test_class=None, **kwargs):
   """Defines a test_suite of web_test targets that wrap a java_test target.
 

--- a/web/py.bzl
+++ b/web/py.bzl
@@ -15,7 +15,6 @@
 
 load("//web/internal:wrap_web_test_suite.bzl", "wrap_web_test_suite")
 
-
 def py_web_test_suite(name, py_test_tags=None, main=None, **kwargs):
   """Defines a test_suite of web_test targets that wrap a py_test target.
 

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -17,7 +17,6 @@ load("//web/internal:java_import_external.bzl", "java_import_external")
 load("//web/internal:platform_http_file.bzl", "platform_http_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 
-
 def web_test_repositories(**kwargs):
   """Defines external repositories required by Webtesting Rules.
 
@@ -87,7 +86,6 @@ def web_test_repositories(**kwargs):
   if kwargs.keys():
     print("The following parameters are unknown: " + str(kwargs.keys()))
 
-
 def should_create_repository(name, args):
   """Returns whether the name repository should be created.
 
@@ -104,7 +102,6 @@ def should_create_repository(name, args):
   if native.existing_rule(name):
     return False
   return True
-
 
 def browser_repositories(firefox=False, chromium=False):
   """Sets up repositories for browsers defined in //browsers/....
@@ -123,7 +120,6 @@ def browser_repositories(firefox=False, chromium=False):
     org_mozilla_firefox()
     org_mozilla_geckodriver()
 
-
 def bazel_skylib():
   native.http_archive(
       name="bazel_skylib",
@@ -133,7 +129,6 @@ def bazel_skylib():
           "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.tar.gz",
       ],
   )
-
 
 def com_github_blang_semver():
   go_repository(
@@ -145,7 +140,6 @@ def com_github_blang_semver():
           "https://github.com/blang/semver/archive/v3.5.1.tar.gz",
       ])
 
-
 def com_github_gorilla_context():
   go_repository(
       name="com_github_gorilla_context",
@@ -155,7 +149,6 @@ def com_github_gorilla_context():
       urls=[
           "https://github.com/gorilla/context/archive/v1.1.tar.gz",
       ])
-
 
 def com_github_gorilla_mux():
   go_repository(
@@ -167,7 +160,6 @@ def com_github_gorilla_mux():
           "https://github.com/gorilla/mux/archive/v1.6.1.tar.gz",
       ])
 
-
 def com_github_tebeka_selenium():
   go_repository(
       name="com_github_tebeka_selenium",
@@ -177,7 +169,6 @@ def com_github_tebeka_selenium():
       urls=[
           "https://github.com/tebeka/selenium/archive/a789e65b0e7f126888873e84f528c1c8537dff3e.tar.gz",
       ])
-
 
 def com_google_code_findbugs_jsr305():
   java_import_external(
@@ -190,7 +181,6 @@ def com_google_code_findbugs_jsr305():
       licenses=["notice"]  # BSD 3-clause
   )
 
-
 def com_google_code_gson():
   java_import_external(
       name="com_google_code_gson",
@@ -202,7 +192,6 @@ def com_google_code_gson():
       licenses=["notice"],  # The Apache Software License, Version 2.0
   )
 
-
 def com_google_errorprone_error_prone_annotations():
   java_import_external(
       name="com_google_errorprone_error_prone_annotations",
@@ -213,7 +202,6 @@ def com_google_errorprone_error_prone_annotations():
       ],
       licenses=["notice"]  # Apache 2.0
   )
-
 
 def com_google_guava():
   java_import_external(
@@ -229,7 +217,6 @@ def com_google_guava():
           "@com_google_errorprone_error_prone_annotations",
       ])
 
-
 def com_squareup_okhttp3_okhttp():
   java_import_external(
       name="com_squareup_okhttp3_okhttp",
@@ -244,7 +231,6 @@ def com_squareup_okhttp3_okhttp():
           "@com_google_code_findbugs_jsr305",
       ])
 
-
 def com_squareup_okio():
   java_import_external(
       name="com_squareup_okio",
@@ -255,7 +241,6 @@ def com_squareup_okio():
       "4633c331f50642ebe795dc089d6a5928aff43071c9d17e7840a009eea2fe95a3",
       licenses=["notice"],  # Apache 2.0
       deps=["@com_google_code_findbugs_jsr305"])
-
 
 def commons_codec():
   java_import_external(
@@ -268,7 +253,6 @@ def commons_codec():
       licenses=["notice"]  # Apache License, Version 2.0
   )
 
-
 def commons_logging():
   java_import_external(
       name="commons_logging",
@@ -279,7 +263,6 @@ def commons_logging():
       ],
       licenses=["notice"]  # The Apache Software License, Version 2.0
   )
-
 
 def junit():
   java_import_external(
@@ -292,7 +275,6 @@ def junit():
       licenses=["reciprocal"],  # Eclipse Public License 1.0
       testonly_=1,
       deps=["@org_hamcrest_core"])
-
 
 def net_bytebuddy():
   java_import_external(
@@ -308,7 +290,6 @@ def net_bytebuddy():
       # http://www.apache.org/licenses/
       licenses=["restricted"])
 
-
 def org_apache_commons_exec():
   java_import_external(
       name="org_apache_commons_exec",
@@ -319,7 +300,6 @@ def org_apache_commons_exec():
       ],
       licenses=["notice"]  # Apache License, Version 2.0
   )
-
 
 def org_apache_httpcomponents_httpclient():
   java_import_external(
@@ -336,7 +316,6 @@ def org_apache_httpcomponents_httpclient():
           "@commons_codec",
       ])
 
-
 def org_apache_httpcomponents_httpcore():
   java_import_external(
       name="org_apache_httpcomponents_httpcore",
@@ -347,7 +326,6 @@ def org_apache_httpcomponents_httpcore():
       ],
       licenses=["notice"]  # Apache License, Version 2.0
   )
-
 
 def org_chromium_chromedriver():
   platform_http_file(
@@ -368,7 +346,6 @@ def org_chromium_chromedriver():
           "http://chromedriver.storage.googleapis.com/2.35/chromedriver_win32.zip"
       ])
 
-
 def org_chromium_chromium():
   platform_http_file(
       name="org_chromium_chromium",
@@ -388,7 +365,6 @@ def org_chromium_chromium():
           "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/539249/chrome-win32.zip"
       ])
 
-
 def org_hamcrest_core():
   java_import_external(
       name="org_hamcrest_core",
@@ -400,7 +376,6 @@ def org_hamcrest_core():
       licenses=["notice"],  # New BSD License
       testonly_=1)
 
-
 def org_json():
   java_import_external(
       name="org_json",
@@ -411,7 +386,6 @@ def org_json():
       ],
       licenses=["notice"]  # MIT-style license
   )
-
 
 def org_mozilla_firefox():
   platform_http_file(
@@ -426,7 +400,6 @@ def org_mozilla_firefox():
       macos_urls=[
           "https://ftp.mozilla.org/pub/firefox/releases/52.1.2esr/firefox-52.1.2esr.mac-x86_64.sdk.tar.bz2",
       ])
-
 
 def org_mozilla_geckodriver():
   platform_http_file(
@@ -443,7 +416,6 @@ def org_mozilla_geckodriver():
           "https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-macos.tar.gz",
       ])
 
-
 def org_seleniumhq_py():
   native.new_http_archive(
       name="org_seleniumhq_py",
@@ -453,7 +425,6 @@ def org_seleniumhq_py():
       urls=[
           "https://pypi.python.org/packages/d4/28/8124d32415bd3d67fabea52480395427576b582771283e89ce10a56d9e5b/selenium-3.11.0.tar.gz"
       ])
-
 
 def org_seleniumhq_selenium_api():
   java_import_external(
@@ -465,7 +436,6 @@ def org_seleniumhq_selenium_api():
       ],
       licenses=["notice"],  # The Apache Software License, Version 2.0
       testonly_=1)
-
 
 def org_seleniumhq_selenium_remote_driver():
   java_import_external(

--- a/web/scala.bzl
+++ b/web/scala.bzl
@@ -16,7 +16,6 @@
 load("//web/internal:wrap_web_test_suite.bzl", "wrap_web_test_suite")
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
 
-
 def scala_web_test_suite(name, scala_test_tags=None, **kwargs):
   """Defines a test_suite of web_test targets that wrap a java_test target.
 

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -13,24 +13,36 @@
 # limitations under the License.
 """Public definitions for web_test related build rules."""
 
-load("//web/internal:browser.bzl", browser_alias="browser")
+load(
+    "//web/internal:browser.bzl",
+    browser_alias = "browser",
+)
 load("//web/internal:collections.bzl", "lists", "maps")
 load("//web/internal:constants.bzl", "DEFAULT_TEST_SUITE_TAGS")
-load("//web/internal:web_test.bzl", web_test_alias="web_test")
+load(
+    "//web/internal:web_test.bzl",
+    web_test_alias = "web_test",
+)
 load(
     "//web/internal:web_test_archive.bzl",
-    web_test_archive_alias="web_test_archive")
+    web_test_archive_alias = "web_test_archive",
+)
 load(
     "//web/internal:web_test_config.bzl",
-    web_test_config_alias="web_test_config")
-load("//web/internal:web_test_files.bzl", web_test_files_alias="web_test_files")
+    web_test_config_alias = "web_test_config",
+)
+load(
+    "//web/internal:web_test_files.bzl",
+    web_test_files_alias = "web_test_files",
+)
 load(
     "//web/internal:web_test_named_executable.bzl",
-    web_test_named_executable_alias="web_test_named_executable")
+    web_test_named_executable_alias = "web_test_named_executable",
+)
 load(
     "//web/internal:web_test_named_file.bzl",
-    web_test_named_file_alias="web_test_named_file")
-
+    web_test_named_file_alias = "web_test_named_file",
+)
 
 def web_test_suite(name,
                    browsers,
@@ -85,7 +97,6 @@ def web_test_suite(name,
   native.test_suite(
       name=name, tests=tests, tags=test_suite_tags, visibility=visibility)
 
-
 def _apply_browser_overrides(kwargs, overrides):
   """Handles browser-specific options that override the top-level definitions.
 
@@ -103,11 +114,9 @@ def _apply_browser_overrides(kwargs, overrides):
 
   return overridden_kwargs
 
-
 def browser(testonly=True, **kwargs):
   """Wrapper around browser to correctly set defaults."""
   browser_alias(testonly=testonly, **kwargs)
-
 
 def web_test(config=None, launcher=None, size=None, **kwargs):
   """Wrapper around web_test to correctly set defaults."""
@@ -116,26 +125,21 @@ def web_test(config=None, launcher=None, size=None, **kwargs):
   size = size or "large"
   web_test_alias(config=config, launcher=launcher, size=size, **kwargs)
 
-
 def web_test_config(testonly=True, **kwargs):
   """Wrapper around web_test_config to correctly set defaults."""
   web_test_config_alias(testonly=testonly, **kwargs)
-
 
 def web_test_named_executable(testonly=True, **kwargs):
   """Wrapper around web_test_named_executable to correctly set defaults."""
   web_test_named_executable_alias(testonly=testonly, **kwargs)
 
-
 def web_test_named_file(testonly=True, **kwargs):
   """Wrapper around web_test_named_file to correctly set defaults."""
   web_test_named_file_alias(testonly=testonly, **kwargs)
 
-
 def web_test_archive(testonly=True, **kwargs):
   """Wrapper around web_test_archive to correctly set defaults."""
   web_test_archive_alias(testonly=testonly, **kwargs)
-
 
 def web_test_files(testonly=True, **kwargs):
   """Wrapper around web_test_files to correctly set defaults."""


### PR DESCRIPTION
Previously we used pyformat, but now buildifier supports skylark.