### PR TITLE
Improve shutdown

### DIFF
--- a/browsers/chromium-local.json
+++ b/browsers/chromium-local.json
@@ -3,12 +3,13 @@
   "capabilities" : {
     "browserName" : "chromium",
     "chromeOptions" : {
-      "args" : ["headless", "use-gl=swiftshader-webgl"],
+      "args" : ["--headless", "--use-gl=swiftshader-webgl"],
       "binary" : "%CHROMIUM%"
     },
     "google:wslConfig": {
     	"binary": "%CHROMEDRIVER%",
-    	"args": ["--port=%WSL:PORT%"]
+    	"args": ["--port=%WSL:PORT%"],
+      "shutdownEndpoint": true
     }
   }
 }

--- a/browsers/firefox-local.json
+++ b/browsers/firefox-local.json
@@ -4,11 +4,12 @@
         "browserName": "firefox",
         "moz:firefoxOptions": {
             "binary": "%FIREFOX%",
-            "args": ["-headless"]
+            "args": ["--headless"]
         },
         "google:wslConfig": {
 	    	"binary": "%GECKODRIVER%",
-	    	"args": ["--port", "%WSL:PORT%", "--binary", "%FIREFOX%"]
+	    	"args": ["--port", "%WSL:PORT%", "--binary", "%FIREFOX%"],
+            "shutdownEndpoint": false
 	    }
     }
 } 

--- a/go/wsl/hub/hub.go
+++ b/go/wsl/hub/hub.go
@@ -130,7 +130,7 @@ func (h *Hub) newSessionFromCaps(ctx context.Context, caps *capabilities.Capabil
 
 			s, err := d.NewSession(ctx, caps, w)
 			if err != nil {
-				ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+				ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 				defer cancel()
 				d.Shutdown(ctx)
 				return "", nil, err
@@ -154,7 +154,7 @@ func (h *Hub) newSessionFromCaps(ctx context.Context, caps *capabilities.Capabil
 				FirstMatch:  []map[string]interface{}{fm},
 			}, w)
 			if err != nil {
-				ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+				ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 				defer cancel()
 				d.Shutdown(ctx)
 				continue

--- a/go/wsl/hub/hub.go
+++ b/go/wsl/hub/hub.go
@@ -173,7 +173,7 @@ func (h *Hub) quitSession(session string, driver *driver.Driver, w http.Response
 
 	driver.Forward(w, r)
 
-	ctx, cancel := context.WithTimeout(r.Context(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
 	if err := driver.Shutdown(ctx); err != nil {
 		log.Printf("Error shutting down driver: %v", err)

--- a/go/wsl/wsl.go
+++ b/go/wsl/wsl.go
@@ -66,14 +66,18 @@ func startServer(ctx context.Context, port int, handler http.Handler) error {
 func createHandler(hub http.Handler, downloadRoot string, shutdown func()) http.Handler {
 	handler := http.NewServeMux()
 
-	handler.HandleFunc("/quitquitquit", func(w http.ResponseWriter, _ *http.Request) {
+	shutdownFunc := func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.WriteHeader(http.StatusOK)
 
 		w.Write([]byte("shutting down"))
 		shutdown()
-	})
+	}
+
+	handler.HandleFunc("/quitquitquit", shutdownFunc)
+
+	handler.HandleFunc("/shutdown", shutdownFunc)	
 
 	handler.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")


### PR DESCRIPTION
Add support for using shutdown endpoint to stop drivers from WSL.
Add shutdown endpoint to WSL.
Configure browsers to use shutdown endpoint as appropriate.