### PR TITLE
Add browser:<unqualified_name> tag to web_test targets

### DIFF
--- a/web/web.bzl
+++ b/web/web.bzl
@@ -86,6 +86,9 @@ def web_test_suite(name,
     overrides = browser_overrides.get(browser) or browser_overrides.get(
         unqualified_browser) or {}
     overridden_kwargs = _apply_browser_overrides(kwargs, overrides)
+    if not 'tags' in overridden_kwargs:
+      overridden_kwargs['tags'] = []
+    overridden_kwargs['tags'] = lists.clone(overridden_kwargs['tags']) + ["browser:" + unqualified_browser]
 
     web_test(
         name=test_name,


### PR DESCRIPTION
This tag can be used to filter out tests using the `test_tag_filters` command line option.

For example,

`bazel test --test_tag_filters=-browser:chromium-local ...`

would not run any tests for the `chromium-local` browser

//cc @alexeagle