### PR TITLE
Fix the sha256sum for the bazel_skylib dependency

### DIFF
--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -123,7 +123,7 @@ def browser_repositories(firefox=False, chromium=False):
 def bazel_skylib():
   native.http_archive(
       name="bazel_skylib",
-      sha256="ce27a2007deda8a1de65df9de3d4cd93a5360ead43c5ff3017ae6b3a2abe485e",
+      sha256="d7cffbed034d1203858ca19ff2e88d241781f45652a4c719ed48eedc74bc82a9",
       strip_prefix="bazel-skylib-0.3.1",
       urls=[
           "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.tar.gz",


### PR DESCRIPTION
Not sure how it's possible that the checksum changed, maybe the repo was re-tagged with the same tag?