### PR TITLE
Mirror rules_webtesting dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,26 +16,30 @@
 #
 workspace(name = "io_bazel_rules_webtesting")
 
-rules_go_version = "0.10.3"
+# NOTE: URLs are mirrored by an asynchronous review process. They must
+#       be greppable for that to happen. It's OK to submit broken mirror
+#       URLs, so long as they're correctly formatted. Bazel's downloader
+#       has fast failover.
 
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/{v}/rules_go-{v}.tar.gz".format(v = rules_go_version),
-        "https://github.com/bazelbuild/rules_go/releases/download/{v}/rules_go-{v}.tar.gz".format(v = rules_go_version),
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
     ],
 )
-
-gazelle_version = "0.10.1"
 
 http_archive(
     name = "bazel_gazelle",
     sha256 = "d03625db67e9fb0905bbd206fa97e32ae9da894fe234a493e7517fd25faec914",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/{v}/bazel-gazelle-{v}.tar.gz".format(v = gazelle_version),
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/0.10.1/bazel-gazelle-0.10.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.1/bazel-gazelle-0.10.1.tar.gz",
+    ],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -54,14 +58,14 @@ browser_repositories(
     firefox = True,
 )
 
-rules_scala_version = "55c5bd2c4af311008bcfa0f989af39026ed567fe"
-
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "d45b5d621f216eee004e1aaed0f9f9df43c75f55c81fa742b27fc6969d2cbc2b",
-    strip_prefix = "rules_scala-{v}".format(v = rules_scala_version),
-    type = "zip",
-    url = "https://github.com/bazelbuild/rules_scala/archive/{v}.zip".format(v = rules_scala_version),
+    sha256 = "0ac3ef277205d10ca353a5760da9710c8dbf2fca5bd1d2b6143a073ed2a1a50f",
+    strip_prefix = "rules_scala-55c5bd2c4af311008bcfa0f989af39026ed567fe",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_scala/archive/55c5bd2c4af311008bcfa0f989af39026ed567fe.tar.gz",
+        "https://github.com/bazelbuild/rules_scala/archive/55c5bd2c4af311008bcfa0f989af39026ed567fe.tar.gz",
+    ],
 )
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -40,6 +40,7 @@ def _impl(repository_ctx):
         "\n".join([
             ("# DO NOT EDIT: automatically generated BUILD file for " +
              "platform_http_file rule " + repository_ctx.name),
+            "licenses(%s)" % repr(repository_ctx.attr.licenses),
             "filegroup(",
             "    name = 'file',",
             "    srcs = ['%s']," % basename,
@@ -50,6 +51,7 @@ def _impl(repository_ctx):
 
 platform_http_file = repository_rule(
     attrs = {
+        "licenses": attr.string_list(mandatory=True, allow_empty=False),
         "amd64_urls": attr.string_list(),
         "amd64_sha256": attr.string(),
         "macos_urls": attr.string_list(),

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -17,6 +17,11 @@ load("//web/internal:java_import_external.bzl", "java_import_external")
 load("//web/internal:platform_http_file.bzl", "platform_http_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 
+# NOTE: URLs are mirrored by an asynchronous review process. They must
+#       be greppable for that to happen. It's OK to submit broken mirror
+#       URLs, so long as they're correctly formatted. Bazel's downloader
+#       has fast failover.
+
 def web_test_repositories(**kwargs):
     """Defines external repositories required by Webtesting Rules.
 
@@ -139,6 +144,7 @@ def bazel_skylib():
         sha256 = "d7cffbed034d1203858ca19ff2e88d241781f45652a4c719ed48eedc74bc82a9",
         strip_prefix = "bazel-skylib-0.3.1",
         urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.3.1.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.tar.gz",
         ],
     )
@@ -150,6 +156,7 @@ def com_github_blang_semver():
         sha256 = "3d9da53f4c2d3169bfa9b25f2f36f301a37556a47259c870881524c643c69c57",
         strip_prefix = "semver-3.5.1",
         urls = [
+            "https://mirror.bazel.build/github.com/blang/semver/archive/v3.5.1.tar.gz",
             "https://github.com/blang/semver/archive/v3.5.1.tar.gz",
         ],
     )
@@ -161,6 +168,7 @@ def com_github_gorilla_context():
         sha256 = "12a849b4e9a08619233d4490a281aa2d34a69f9eaf85c2295f5357927e4d1763",
         strip_prefix = "context-1.1",
         urls = [
+            "https://mirror.bazel.build/github.com/gorilla/context/archive/v1.1.tar.gz",
             "https://github.com/gorilla/context/archive/v1.1.tar.gz",
         ],
     )
@@ -172,6 +180,7 @@ def com_github_gorilla_mux():
         sha256 = "fe4d6909570b53121eb0d5e6f933ef7c49d5de094705af6ba07fab9c299df0f9",
         strip_prefix = "mux-1.6.1",
         urls = [
+            "https://mirror.bazel.build/github.com/gorilla/mux/archive/v1.6.1.tar.gz",
             "https://github.com/gorilla/mux/archive/v1.6.1.tar.gz",
         ],
     )
@@ -183,6 +192,7 @@ def com_github_tebeka_selenium():
         sha256 = "c731518d8f4724b1c581bdca90215978bf4d2658a5dc49b720d7c61294888396",
         strip_prefix = "selenium-a789e65b0e7f126888873e84f528c1c8537dff3e",
         urls = [
+            "https://mirror.bazel.build/github.com/tebeka/selenium/archive/a789e65b0e7f126888873e84f528c1c8537dff3e.tar.gz",
             "https://github.com/tebeka/selenium/archive/a789e65b0e7f126888873e84f528c1c8537dff3e.tar.gz",
         ],
     )
@@ -191,7 +201,8 @@ def com_google_code_findbugs_jsr305():
     java_import_external(
         name = "com_google_code_findbugs_jsr305",
         jar_urls = [
-            "http://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+            "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
         ],
         jar_sha256 =
             "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
@@ -204,7 +215,8 @@ def com_google_code_gson():
         jar_sha256 =
             "b7134929f7cc7c04021ec1cc27ef63ab907e410cf0588e397b8851181eb91092",
         jar_urls = [
-            "http://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar",
+            "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar",
         ],
         licenses = ["notice"],  # The Apache Software License, Version 2.0
     )
@@ -215,7 +227,8 @@ def com_google_errorprone_error_prone_annotations():
         jar_sha256 =
             "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
         jar_urls = [
-            "http://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
+            "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
         ],
         licenses = ["notice"],  # Apache 2.0
     )
@@ -226,7 +239,8 @@ def com_google_guava():
         jar_sha256 =
             "31bfe27bdf9cba00cb4f3691136d3bc7847dfc87bfe772ca7a9eb68ff31d79f5",
         jar_urls = [
-            "http://repo1.maven.org/maven2/com/google/guava/guava/24.1-jre/guava-24.1-jre.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/guava/guava/24.1-jre/guava-24.1-jre.jar",
+            "https://repo1.maven.org/maven2/com/google/guava/guava/24.1-jre/guava-24.1-jre.jar",
         ],
         licenses = ["notice"],  # Apache 2.0
         exports = [
@@ -239,7 +253,8 @@ def com_squareup_okhttp3_okhttp():
     java_import_external(
         name = "com_squareup_okhttp3_okhttp",
         jar_urls = [
-            "http://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
+            "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
         ],
         jar_sha256 =
             "a0d01017a42bba26e507fc6d448bb36e536f4b6e612f7c42de30bbdac2b7785e",
@@ -254,7 +269,8 @@ def com_squareup_okio():
     java_import_external(
         name = "com_squareup_okio",
         jar_urls = [
-            "http://repo1.maven.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0.jar",
+            "https://repo1.maven.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0.jar",
         ],
         jar_sha256 =
             "4633c331f50642ebe795dc089d6a5928aff43071c9d17e7840a009eea2fe95a3",
@@ -268,7 +284,8 @@ def commons_codec():
         jar_sha256 =
             "e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d",
         jar_urls = [
-            "http://repo1.maven.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar",
+            "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar",
         ],
         licenses = ["notice"],  # Apache License, Version 2.0
     )
@@ -279,7 +296,8 @@ def commons_logging():
         jar_sha256 =
             "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
         jar_urls = [
-            "http://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+            "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
         ],
         licenses = ["notice"],  # The Apache Software License, Version 2.0
     )
@@ -290,7 +308,8 @@ def junit():
         jar_sha256 =
             "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
         jar_urls = [
-            "http://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
+            "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
         ],
         licenses = ["reciprocal"],  # Eclipse Public License 1.0
         testonly_ = 1,
@@ -303,13 +322,10 @@ def net_bytebuddy():
         jar_sha256 =
             "1c7c222d5c317481538117e54029c289c5a1605a3cdcadf4e7f7cc1fe7469277",
         jar_urls = [
-            "http://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.3/byte-buddy-1.8.3.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.3/byte-buddy-1.8.3.jar",
+            "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.3/byte-buddy-1.8.3.jar",
         ],
-        # LGPL, version 2.1
-        # http://www.gnu.org/licenses/licenses.html
-        # ASL, version 2
-        # http://www.apache.org/licenses/
-        licenses = ["restricted"],
+        licenses = ["notice"],  # Apache 2.0
     )
 
 def org_apache_commons_exec():
@@ -318,7 +334,8 @@ def org_apache_commons_exec():
         jar_sha256 =
             "cb49812dc1bfb0ea4f20f398bcae1a88c6406e213e67f7524fb10d4f8ad9347b",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
+            "https://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
         ],
         licenses = ["notice"],  # Apache License, Version 2.0
     )
@@ -329,7 +346,8 @@ def org_apache_httpcomponents_httpclient():
         jar_sha256 =
             "7e97724443ad2a25ad8c73183431d47cc7946271bcbbdfa91a8a17522a566573",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar",
+            "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar",
         ],
         licenses = ["notice"],  # Apache License, Version 2.0
         deps = [
@@ -345,7 +363,8 @@ def org_apache_httpcomponents_httpcore():
         jar_sha256 =
             "1b4a1c0b9b4222eda70108d3c6e2befd4a6be3d9f78ff53dd7a94966fdf51fc5",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar",
+            "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar",
         ],
         licenses = ["notice"],  # Apache License, Version 2.0
     )
@@ -353,40 +372,42 @@ def org_apache_httpcomponents_httpcore():
 def org_chromium_chromedriver():
     platform_http_file(
         name = "org_chromium_chromedriver",
+        licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
         amd64_sha256 =
             "67fad24c4a85e3f33f51c97924a98b619722db15ce92dcd27484fb748af93e8e",
         amd64_urls = [
-            "http://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip",
+            "https://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip",
         ],
         macos_sha256 =
             "c11521bdc991874a0a29cf36beea6a4b8d73616ce6c8d1e6b90067d85718aa87",
         macos_urls = [
-            "http://chromedriver.storage.googleapis.com/2.35/chromedriver_mac64.zip",
+            "https://chromedriver.storage.googleapis.com/2.35/chromedriver_mac64.zip",
         ],
         windows_sha256 =
             "b32fdcc1c19bb829032f0447a8aac4f5436565ec1d0f105b63c4451ba4e6ae8a",
         windows_urls = [
-            "http://chromedriver.storage.googleapis.com/2.35/chromedriver_win32.zip",
+            "https://chromedriver.storage.googleapis.com/2.35/chromedriver_win32.zip",
         ],
     )
 
 def org_chromium_chromium():
     platform_http_file(
         name = "org_chromium_chromium",
+        licenses = ["notice"],  # BSD 3-clause (maybe more?)
         amd64_sha256 =
             "51a189382cb5272d240a729da0ae77d0211c1bbc0d10b701a2723b5b068c1e3a",
         amd64_urls = [
-            "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/539259/chrome-linux.zip",
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/539259/chrome-linux.zip",
         ],
         macos_sha256 =
             "866ec9aa4e07cc86ae1d5aeb6e9bdafb5f94989c7c0be661302930ad667f41f3",
         macos_urls = [
-            "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/539251/chrome-mac.zip",
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/539251/chrome-mac.zip",
         ],
         windows_sha256 =
             "be4fcc7257d85c12ae2de10aef0150ddbb7b9ecbd5ada6a898d247cf867a058a",
         windows_urls = [
-            "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/539249/chrome-win32.zip",
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/539249/chrome-win32.zip",
         ],
     )
 
@@ -396,7 +417,8 @@ def org_hamcrest_core():
         jar_sha256 =
             "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
         ],
         licenses = ["notice"],  # New BSD License
         testonly_ = 1,
@@ -408,7 +430,8 @@ def org_json():
         jar_sha256 =
             "3eddf6d9d50e770650e62abe62885f4393aa911430ecde73ebafb1ffd2cfad16",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/json/json/20180130/json-20180130.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/json/json/20180130/json-20180130.jar",
+            "https://repo1.maven.org/maven2/org/json/json/20180130/json-20180130.jar",
         ],
         licenses = ["notice"],  # MIT-style license
     )
@@ -416,14 +439,17 @@ def org_json():
 def org_mozilla_firefox():
     platform_http_file(
         name = "org_mozilla_firefox",
+        licenses = ["reciprocal"],  # MPL 2.0
         amd64_sha256 =
             "134fec04819eb56fa7b644cdd6d89623b21f4020bbedc3bd122db2a2caa4e434",
         amd64_urls = [
+            "https://mirror.bazel.build/ftp.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/firefox-58.0.tar.bz2",
             "https://ftp.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/firefox-58.0.tar.bz2",
         ],
         macos_sha256 =
             "a853eb20821a21c0bedeb0263d7b5975e7704f20b78edfef129c73804b1fb962",
         macos_urls = [
+            "https://mirror.bazel.build/ftp.mozilla.org/pub/firefox/releases/58.0/mac/en-US/Firefox%2058.0.dmg",
             "https://ftp.mozilla.org/pub/firefox/releases/58.0/mac/en-US/Firefox%2058.0.dmg",
         ],
     )
@@ -431,15 +457,18 @@ def org_mozilla_firefox():
 def org_mozilla_geckodriver():
     platform_http_file(
         name = "org_mozilla_geckodriver",
+        licenses = ["reciprocal"],  # MPL 2.0
         amd64_sha256 =
             "7f55c4c89695fd1e6f8fc7372345acc1e2dbaa4a8003cee4bd282eed88145937",
         amd64_urls = [
+            "https://mirror.bazel.build/github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz",
             "https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz",
         ],
         macos_sha256 =
             "eb5a2971e5eb4a2fe74a3b8089f0f2cc96eed548c28526b8351f0f459c080836",
         macos_urls = [
-            "http://mirror.bazel.build/github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-macos.tar.gz",
+            # TODO(fisherii): v0.19.1 is mirrored and ready to go.
+            "https://mirror.bazel.build/github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-macos.tar.gz",
             "https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-macos.tar.gz",
         ],
     )
@@ -451,6 +480,7 @@ def org_seleniumhq_py():
         sha256 = "5841fb30c3965866220c34d16de8e3d091e2833fcac385160a63db0c3522a297",
         strip_prefix = "selenium-3.11.0",
         urls = [
+            "https://mirror.bazel.build/pypi.python.org/packages/d4/28/8124d32415bd3d67fabea52480395427576b582771283e89ce10a56d9e5b/selenium-3.11.0.tar.gz",
             "https://pypi.python.org/packages/d4/28/8124d32415bd3d67fabea52480395427576b582771283e89ce10a56d9e5b/selenium-3.11.0.tar.gz",
         ],
     )
@@ -461,7 +491,8 @@ def org_seleniumhq_selenium_api():
         jar_sha256 =
             "3e81810f61a1930d4ca868475cefdbe10b7260e352d09c4bfeda5e9ede5dd538",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.11.0/selenium-api-3.11.0.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.11.0/selenium-api-3.11.0.jar",
+            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.11.0/selenium-api-3.11.0.jar",
         ],
         licenses = ["notice"],  # The Apache Software License, Version 2.0
         testonly_ = 1,
@@ -473,7 +504,8 @@ def org_seleniumhq_selenium_remote_driver():
         jar_sha256 =
             "7a9c23a6a304bdcaec5a642f6641e07f798adc2f213cce456e4a829ad4454deb",
         jar_urls = [
-            "http://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.11.0/selenium-remote-driver-3.11.0.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.11.0/selenium-remote-driver-3.11.0.jar",
+            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.11.0/selenium-remote-driver-3.11.0.jar",
         ],
         licenses = ["notice"],  # The Apache Software License, Version 2.0
         testonly_ = 1,


### PR DESCRIPTION
This should make things faster for you. If you keep the URLs greppable and synced internally, I can keep mirroring them for you.

OOC is Scala an optional dependency?

I ran `bazel test //java/... //javatests/... //scalatests/... //testdata/... //web/... //common/... //browsers/... //build_files/... //third_party/... //testing/...` locally and encountered a bunch of errors that seem to be unrelated.

```
SessionNotCreatedException: Message: environment variable "BUILD_TAG" is not defined
...
SessionNotCreatedException: Message: environment variable "TUNNEL_IDENTIFIER" is not defined
...
1) newWebDriverSession(com.google.testing.web.WebTestTest)
org.openqa.selenium.SessionNotCreatedException: environment variable "TUNNEL_IDENTIFIER" is not defined (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 58 milliseconds
Build info: version: '3.11.0', revision: 'e59cfb3', time: '2018-03-11T20:26:55.152Z'
System info: REDACTED
Driver info: driver.version: RemoteWebDriver
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.openqa.selenium.remote.ErrorHandler.createThrowable(ErrorHandler.java:214)
        at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:166)
        at org.openqa.selenium.remote.JsonWireProtocolResponse.lambda$new$0(JsonWireProtocolResponse.java:53)
        at org.openqa.selenium.remote.JsonWireProtocolResponse.lambda$getResponseFunction$2(JsonWireProtocolResponse.java:91)
        at org.openqa.selenium.remote.ProtocolHandshake.lambda$createSession$0(ProtocolHandshake.java:123)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)
        at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:464)
        at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:126)
        at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:73)
        at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:136)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:545)
        at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:209)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:132)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:145)
        at com.google.testing.web.WebTest.newWebDriverSession(WebTest.java:88)
        at com.google.testing.web.WebTest.newWebDriverSession(WebTest.java:79)
        at com.google.testing.web.WebTestTest.newWebDriverSession(WebTestTest.java:30)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
        at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
        at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:112)
        at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:144)
        at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:82)


ERROR: /usr/local/google/home/jart/code/rules_webtesting/scalatests/com/google/testing/web/screenshotter/BUILD.bazel:23:1: scala //scalatests/com/google/testing/web/screenshotter:ScreenshotterTest_wrapped_test failed (Exit 1)
error: scala.MatchError: strict (of class java.lang.String)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2$$anonfun$apply$4.apply(DependencyAnalyzer.scala:68) 
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2$$anonfun$apply$4.apply(DependencyAnalyzer.scala:62) 
        at scala.Option$WithFilter.foreach(Option.scala:209)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2.apply(DependencyAnalyzer.scala:62)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2.apply(DependencyAnalyzer.scala:60)
        at scala.collection.immutable.HashSet$HashSet1.foreach(HashSet.scala:316)
        at scala.collection.immutable.HashSet$HashTrieSet.foreach(HashSet.scala:972)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1.warnOnIndirectTargetsFoundIn(DependencyAnalyzer.scala:60)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1.run(DependencyAnalyzer.scala:56)
        at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1528)
        at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1513)
        at scala.tools.nsc.Global$Run.compileSources(Global.scala:1508)
        at scala.tools.nsc.Global$Run.compile(Global.scala:1609)
        at scala.tools.nsc.Driver.doCompile(Driver.scala:32)
        at scala.tools.nsc.MainClass.doCompile(Main.scala:23)
        at scala.tools.nsc.Driver.process(Driver.scala:51)
        at io.bazel.rulesscala.scalac.ScalacProcessor.compileScalaSources(ScalacProcessor.java:237)
        at io.bazel.rulesscala.scalac.ScalacProcessor.processRequest(ScalacProcessor.java:68)
        at io.bazel.rulesscala.worker.GenericWorker.run(GenericWorker.java:125)
        at io.bazel.rulesscala.scalac.ScalaCInvoker.main(ScalaCInvoker.java:41)
scala.MatchError: strict (of class java.lang.String)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2$$anonfun$apply$4.apply(DependencyAnalyzer.scala:68) 
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2$$anonfun$apply$4.apply(DependencyAnalyzer.scala:62) 
        at scala.Option$WithFilter.foreach(Option.scala:209)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2.apply(DependencyAnalyzer.scala:62)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1$$anonfun$warnOnIndirectTargetsFoundIn$2.apply(DependencyAnalyzer.scala:60)
        at scala.collection.immutable.HashSet$HashSet1.foreach(HashSet.scala:316)
        at scala.collection.immutable.HashSet$HashTrieSet.foreach(HashSet.scala:972)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1.warnOnIndirectTargetsFoundIn(DependencyAnalyzer.scala:60)
        at third_party.plugin.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer$Component$$anon$1.run(DependencyAnalyzer.scala:56)
        at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1528)
        at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1513)
        at scala.tools.nsc.Global$Run.compileSources(Global.scala:1508)
        at scala.tools.nsc.Global$Run.compile(Global.scala:1609)
        at scala.tools.nsc.Driver.doCompile(Driver.scala:32)
        at scala.tools.nsc.MainClass.doCompile(Main.scala:23)
        at scala.tools.nsc.Driver.process(Driver.scala:51)
        at io.bazel.rulesscala.scalac.ScalacProcessor.compileScalaSources(ScalacProcessor.java:237)
        at io.bazel.rulesscala.scalac.ScalacProcessor.processRequest(ScalacProcessor.java:68)
        at io.bazel.rulesscala.worker.GenericWorker.run(GenericWorker.java:125)
        at io.bazel.rulesscala.scalac.ScalaCInvoker.main(ScalaCInvoker.java:41)
```