### PR TITLE
Gracefully shutdown all drivers.

### DIFF
--- a/web/internal/files.bzl
+++ b/web/internal/files.bzl
@@ -33,7 +33,8 @@ def _long_path(ctx, file):
         # if the file has an owner and that owner has a workspace_root,
         # prepend it.
         return (file.owner.workspace_root + "/" + file.short_path)
-        # otherwise assume the file is in the same workspace as the current rule.
+
+    # otherwise assume the file is in the same workspace as the current rule.
 
     return (ctx.workspace_name + "/" + file.short_path)
 

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -51,7 +51,7 @@ def _impl(repository_ctx):
 
 platform_http_file = repository_rule(
     attrs = {
-        "licenses": attr.string_list(mandatory=True, allow_empty=False),
+        "licenses": attr.string_list(mandatory = True, allow_empty = False),
         "amd64_urls": attr.string_list(),
         "amd64_sha256": attr.string(),
         "macos_urls": attr.string_list(),

--- a/web/web.bzl
+++ b/web/web.bzl
@@ -71,7 +71,7 @@ def web_test_suite(
     if not browsers:
         fail("expected non-empty value for attribute 'browsers'")
 
-        # Check explicitly for None so that users can set this to the empty list.
+    # Check explicitly for None so that users can set this to the empty list.
     if test_suite_tags == None:
         test_suite_tags = DEFAULT_TEST_SUITE_TAGS
 


### PR DESCRIPTION
- For drivers that do not support shutdown attempt to use SIGTERM or SIGINT.
- Format .bzl files with updated version of buildifier.