### PR TITLE
Add WSLPORT and WSLENV capabilities variables:

### DIFF
--- a/browsers/chromium-local.json
+++ b/browsers/chromium-local.json
@@ -11,7 +11,8 @@
     },
     "google:wslConfig": {
       "binary": "%FILE:CHROMEDRIVER%",
-      "args": ["--port=%WSL:PORT%"],
+      "port":"%WSLPORT:WSL%",
+      "args": ["--port=%WSLPORT:WSL%"],
       "status": true,
       "shutdown": true
     }

--- a/browsers/firefox-local.json
+++ b/browsers/firefox-local.json
@@ -8,7 +8,12 @@
     },
     "google:wslConfig": {
       "binary": "%FILE:GECKODRIVER%",
-      "args": ["--port=%WSL:PORT%"],
+      "port":"%WSLPORT:WSL%",
+      "args": [
+        "--port=%WSLPORT:WSL%",
+        "--host=%WSL:HOST_IP%",
+        "--marionette-port=%WSLPORT:MARIONETTE%"
+      ],
       "status": true,
       "shutdown": false
     }

--- a/go/wsl/hub/BUILD.bazel
+++ b/go/wsl/hub/BUILD.bazel
@@ -29,5 +29,6 @@ go_library(
         "//go/httphelper:go_default_library",
         "//go/metadata/capabilities:go_default_library",
         "//go/wsl/driver:go_default_library",
+        "//go/wsl/resolver:go_default_library",
     ],
 )

--- a/go/wsl/resolver/BUILD
+++ b/go/wsl/resolver/BUILD
@@ -22,13 +22,11 @@ licenses(["notice"])  # Apache 2.0
 
 go_library(
     name = "go_default_library",
-    srcs = ["driver.go"],
-    importpath = "github.com/bazelbuild/rules_webtesting/go/wsl/driver",
-    visibility = ["//go/wsl:__subpackages__"],
+    srcs = ["resolver.go"],
+    importpath = "github.com/bazelbuild/rules_webtesting/go/wsl/resolver",
+    visibility = ["//visibility:public"],
     deps = [
-        "//go/cmdhelper:go_default_library",
-        "//go/httphelper:go_default_library",
         "//go/metadata/capabilities:go_default_library",
-        "//go/webdriver:go_default_library",
+        "//go/portpicker:go_default_library",
     ],
 )

--- a/go/wsl/resolver/resolver.go
+++ b/go/wsl/resolver/resolver.go
@@ -1,0 +1,73 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resolver resolves WSL, WSLPORT, and WSLENV variables in capabilities.
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/bazelbuild/rules_webtesting/go/metadata/capabilities"
+	"github.com/bazelbuild/rules_webtesting/go/portpicker"
+)
+
+// Resolver returns a capabilities.Resolver for WSL, WSLPORT, and WSLENV capabilities variables.
+func New(sessionID string) capabilities.Resolver {
+	ports := map[string]string{}
+
+	return func(p, n string) (string, error) {
+		switch p {
+		case "WSLPORT":
+			portStr, ok := ports[n]
+			if ok {
+				return portStr, nil
+			}
+			port, err := portpicker.PickUnusedPort()
+			if err != nil {
+				return "", err
+			}
+			portStr = strconv.Itoa(port)
+			ports[n] = portStr
+			return portStr, nil
+		case "WSLENV":
+			env, ok := os.LookupEnv(n)
+			if !ok {
+				return "", fmt.Errorf("environment variable %s is undefined", n)
+			}
+			return env, nil
+		case "WSL":
+			switch n {
+			case "SESSION_ID":
+				return sessionID, nil
+			case "HOST_IP":
+				ips, err := net.LookupIP("localhost")
+				if err != nil {
+					return "", err
+				}
+				if len(ips) == 0 {
+					return "", errors.New("no ip found for localhost")
+				}
+				return ips[0].String(), nil
+			default:
+				return "", fmt.Errorf("unknown variable WSL:%s", n)
+			}
+		default:
+			return capabilities.NoOPResolver(p, n)
+		}
+	}
+}


### PR DESCRIPTION
- WSLPORT variables generate a new unique IP for each different name.
- WSLENV provides access to environment variables where WSL is running
(useful if WSL is running on a different host than WTL).
- WSL:PORT variable is no longer supported.
- port is now required in wslConfig (can use a WSLPORT variable if you
want WSL to pick a port).
- WSL:HOST_IP capability variable provides access to the IP for
"localhost" (useful in IPv6- or IPv4-only environments.