### PR TITLE
Move responsibility for proxy port selection.

### DIFF
--- a/go/metadata/metadata_test.go
+++ b/go/metadata/metadata_test.go
@@ -227,11 +227,11 @@ func TestMergeNamedFiles(t *testing.T) {
 				return
 			}
 			if tc.result == nil {
-				t.Errorf("Got %#v, expected error", result)
+				t.Errorf("Got %s, expected error", result)
 				return
 			}
 			if !reflect.DeepEqual(result, tc.result) {
-				t.Errorf("Got %v, expected %v", result, tc.result)
+				t.Errorf("Got %s, expected %s", result, tc.result)
 			}
 		})
 	}
@@ -292,10 +292,10 @@ func TestMergeWebTestFiles(t *testing.T) {
 				return
 			}
 			if tc.result == nil {
-				t.Fatalf("Got %#v, expected error", result)
+				t.Fatalf("Got %v, expected error", result)
 			}
 			if !reflect.DeepEqual(result, tc.result) {
-				t.Errorf("Got %#v, expected %#v", result, tc.result)
+				t.Errorf("Got %v, expected %v", result, tc.result)
 			}
 		})
 	}
@@ -375,11 +375,11 @@ func TestNormalizeWebTestFiles(t *testing.T) {
 				return
 			}
 			if tc.err {
-				t.Fatalf("Got %#v, expected error", result)
+				t.Fatalf("Got %v, expected error", result)
 			}
 
 			if !reflect.DeepEqual(result, tc.result) {
-				t.Fatalf("Got  %#v, expected %#v", result, tc.result)
+				t.Fatalf("Got  %v, expected %v", result, tc.result)
 			}
 		})
 	}

--- a/go/metadata/web_test_files.go
+++ b/go/metadata/web_test_files.go
@@ -55,6 +55,7 @@ type WebTestFiles struct {
 
 func normalizeWebTestFiles(in []*WebTestFiles) ([]*WebTestFiles, error) {
 	merged := map[string]*WebTestFiles{}
+	var archiveFiles []string
 
 	for _, a := range in {
 		// skip entries with no named files.
@@ -68,13 +69,15 @@ func normalizeWebTestFiles(in []*WebTestFiles) ([]*WebTestFiles, error) {
 			}
 			merged[m.ArchiveFile] = m
 		} else {
+			archiveFiles = append(archiveFiles, a.ArchiveFile)
 			merged[a.ArchiveFile] = a
 		}
 	}
 
 	names := map[string]bool{}
 	var result []*WebTestFiles
-	for _, m := range merged {
+	for _, a := range archiveFiles {
+		m := merged[a]
 		for name := range m.NamedFiles {
 			if names[name] {
 				return nil, fmt.Errorf("name %q exists in multiple WebTestFiles", name)
@@ -167,4 +170,15 @@ func (w *WebTestFiles) extract(m *Metadata) error {
 
 	w.extractedPath = extractPath
 	return nil
+}
+
+func (w *WebTestFiles) String() string {
+	return fmt.Sprintf(
+		`WebTestFiles{
+	ArchiveFile: %q,
+	StripPrefix: %q,
+	NamedFiles: %+v,
+}
+`, w.ArchiveFile, w.StripPrefix, w.NamedFiles)
+
 }

--- a/go/wtl/BUILD.bazel
+++ b/go/wtl/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//go/cmdhelper:go_default_library",
         "//go/errors:go_default_library",
         "//go/metadata:go_default_library",
+        "//go/portpicker:go_default_library",
         "//go/wtl/diagnostics:go_default_library",
         "//go/wtl/environment:go_default_library",
         "//go/wtl/environment/external:go_default_library",

--- a/go/wtl/main/main.go
+++ b/go/wtl/main/main.go
@@ -24,9 +24,11 @@ import (
 )
 
 var (
-	test             = flag.String("test", "", "Test script to launch")
-	metadataFileFlag = flag.String("metadata", "", "metadata file")
-	debuggerPort     = flag.Int("debugger_port", 0, "Start WTL debugger on given port")
+	test             = flag.String("test", "", "Test to run.")
+	metadataFileFlag = flag.String("metadata", "", "Metadata file for the browser.")
+	debuggerPort     = flag.Int("debugger_port", 0, "Port to start WTL debugger on.")
+	httpPort         = flag.Int("http_port", 0, "Port to start WTL HTTP Proxy on.")
+	httpsPort        = flag.Int("https_port", 0, "Port to start WTL HTTPS Proxy on.")
 )
 
 func main() {
@@ -34,7 +36,7 @@ func main() {
 
 	d := diagnostics.NoOP()
 
-	status := wtl.Run(d, *test, *metadataFileFlag, *debuggerPort)
+	status := wtl.Run(d, *test, *metadataFileFlag, *httpPort, *httpsPort, *debuggerPort)
 
 	d.Close()
 	os.Exit(status)

--- a/go/wtl/proxy/BUILD.bazel
+++ b/go/wtl/proxy/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//go/healthreporter:go_default_library",
         "//go/httphelper:go_default_library",
         "//go/metadata:go_default_library",
-        "//go/portpicker:go_default_library",
         "//go/wtl/diagnostics:go_default_library",
         "//go/wtl/environment:go_default_library",
     ],

--- a/go/wtl/proxy/proxy.go
+++ b/go/wtl/proxy/proxy.go
@@ -29,7 +29,6 @@ import (
 	"github.com/bazelbuild/rules_webtesting/go/healthreporter"
 	"github.com/bazelbuild/rules_webtesting/go/httphelper"
 	"github.com/bazelbuild/rules_webtesting/go/metadata"
-	"github.com/bazelbuild/rules_webtesting/go/portpicker"
 	"github.com/bazelbuild/rules_webtesting/go/wtl/diagnostics"
 	"github.com/bazelbuild/rules_webtesting/go/wtl/environment"
 )
@@ -80,28 +79,20 @@ type Proxy struct {
 }
 
 // New creates a new Proxy object.
-func New(env environment.Env, m *metadata.Metadata, d diagnostics.Diagnostics) (*Proxy, error) {
+func New(env environment.Env, m *metadata.Metadata, d diagnostics.Diagnostics, httpPort, httpsPort int) (*Proxy, error) {
 	fqdn, err := httphelper.FQDN()
-	if err != nil {
-		return nil, errors.New(compName, err)
-	}
-
-	httpPort, err := portpicker.PickUnusedPort()
 	if err != nil {
 		return nil, errors.New(compName, err)
 	}
 
 	httpAddress := net.JoinHostPort(fqdn, strconv.Itoa(httpPort))
 
-	httpsPort := -1
 	httpsAddress := ""
 	certs := newCerts(m)
 	if certs != nil {
-		httpsPort, err = portpicker.PickUnusedPort()
-		if err != nil {
-			return nil, errors.New(compName, err)
-		}
 		httpsAddress = net.JoinHostPort(fqdn, strconv.Itoa(httpsPort))
+	} else {
+		httpsPort = -1
 	}
 
 	p := &Proxy{

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -397,17 +397,17 @@ def org_chromium_chromium():
         amd64_sha256 =
             "edb9807d40a57d235d8477beabe1dfa3d98e275312e7a48bc0cb9b44adb68236",
         amd64_urls = [
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/564817/chrome-linux.zip"
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/564817/chrome-linux.zip",
         ],
         macos_sha256 =
             "b5a8641b187c623fad11ddccaa7f3053ac469a4a568ef8a593341846406ac965",
         macos_urls = [
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/564814/chrome-mac.zip"
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/564814/chrome-mac.zip",
         ],
         windows_sha256 =
             "1684732c817ce037fb22866ad579347c1eeebfb9a404155a78c02b783bcb1d06",
         windows_urls = [
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/564812/chrome-win32.zip"
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/564812/chrome-win32.zip",
         ],
     )
 


### PR DESCRIPTION
- Add httpPort and httpsPort parameters to proxy.New()
- Add httpPort and httpsPort parameters to wtl.Run()
- Have wtl.Run() use portpicker to select ports if passed in ports are
0.
- Add http_port and https_port flags to wtl/main.

Other changes:
- Add String method to WebTestFiles.
- Fix normalizeWebTestFiles to be deterministic.
- Reformt repositories.bzl.