### PR TITLE
Specify --no-sandbox when running headless chromium

### DIFF
--- a/browsers/chromium-local.json
+++ b/browsers/chromium-local.json
@@ -5,7 +5,8 @@
     "chromeOptions" : {
       "binary" : "%FILE:CHROMIUM%",
       "args" : [
-        "--headless", 
+        "--headless",
+        "--no-sandbox",
         "--use-gl=swiftshader-webgl"
       ]
     },


### PR DESCRIPTION
This is needed to order to run the tests in a docker container.