### PR TITLE
Make chromedriver and chromium targets public

### DIFF
--- a/third_party/chromedriver/BUILD.bazel
+++ b/third_party/chromedriver/BUILD.bazel
@@ -32,5 +32,5 @@ web_test_archive(
     named_files = {
         "CHROMEDRIVER": "chromedriver",
     },
-    visibility = ["//browsers:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/third_party/chromium/BUILD.bazel
+++ b/third_party/chromium/BUILD.bazel
@@ -38,5 +38,5 @@ web_test_archive(
         },
     }),
     strip_prefix = "chrome-*",
-    visibility = ["//browsers:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This was necessary to define my own browser definition, such as:

```
load("@io_bazel_rules_webtesting//web:web.bzl", "browser")

browser(
    name = "chromium-local-allow-insecure",
    metadata = "chromium-local-allow-insecure.json",
    deps = [
        "@io_bazel_rules_webtesting//go/wsl",
        "@io_bazel_rules_webtesting//third_party/chromedriver",
        "@io_bazel_rules_webtesting//third_party/chromium",
    ],
)
```

LMK if there is a better way to go about this.