### PR TITLE
Disable //browsers/sauce:chrome-win10 and //browsers/sauce:chrome-win10-connet on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,7 +5,7 @@ platforms:
     build_targets:
     - "//..."
     test_flags:
-    - "--test_tag_filters=-noci"
+    - "--test_tag_filters=-noci,-sauce"
     test_targets:
     - "//..."
   macos:
@@ -13,6 +13,6 @@ platforms:
     build_targets:
     - "//..."
     test_flags:
-    - "--test_tag_filters=-noci"
+    - "--test_tag_filters=-noci,-sauce"
     test_targets:
     - "//..."


### PR DESCRIPTION

Due to https://github.com/bazelbuild/continuous-integration/issues/191