### PR TITLE
Make rules_webtesting lighter weight:

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,110 +7,109 @@ WebDriver.
 
 ## Configure your Bazel project
 
-Add the following to your WORKSPACE file:
+For all languages, you need to add the following to your WORKSPACE file:
 
 ```bzl
-# Load rules_go at master for example purposes only. You should specify
-# a specific version in your project.
-http_archive(
-    name = "io_bazel_rules_go",
-    strip_prefix = "rules_go-master",
-    urls = [
-        "https://github.com/bazelbuild/rules_go/archive/master.tar.gz",
-    ],
-)
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-go_rules_dependencies()
-go_register_toolchains()
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Load rules_webtesting at master for example purposes only. You should specify
-# a specific version in your project.
 http_archive(
     name = "io_bazel_rules_webtesting",
-    strip_prefix = "rules_webtesting-master",
+    sha256 = "<version-specific-sha>",
     urls = [
-        "https://github.com/bazelbuild/rules_webtesting/archive/master.tar.gz",
+        https://github.com/bazelbuild/rules_webtesting/releases/download/<version>/rules_webtesting.tar.gz
     ],
 )
 
 load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
-load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")
 
 web_test_repositories()
+```
 
-platform_http_file(
-    name = "org_chromium_chromium",
-    licenses = ["notice"],  # BSD 3-clause (maybe more?)
-    amd64_sha256 =
-        "6933d0afce6e17304b62029fbbd246cbe9e130eb0d90d7682d3765d3dbc8e1c8",
-    amd64_urls = [
-        "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/561732/chrome-linux.zip",
-    ],
-    macos_sha256 =
-        "084884e91841a923d7b6e81101f0105bbc3b0026f9f6f7a3477f5b313ee89e32",
-    macos_urls = [
-        "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/561733/chrome-mac.zip",
-    ],
-    windows_sha256 =
-        "d1bb728118c12ea436d8ea07dba980789e7d860aa664dd1fad78bc20e8d9391c",
-    windows_urls = [
-        "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/540270/chrome-win32.zip",
+You can use the predefined browsers in `@io_bazel_rules_webtesting//browsers` by
+adding:
+
+```bzl
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories")
+
+browser_repositories(chrome=True, firefox=True)
+```
+
+Then you should add the appropriate dependencies depending on what language you
+are writing your tests in:
+
+### Java
+
+```bzl
+load("@io_bazel_rules_webtesting//web:java_repositories.bzl", "java_repositories")
+
+java_repositories()
+```
+
+### Scala
+
+```bzl
+load("@io_bazel_rules_webtesting//web:java_repositories.bzl", "java_repositories")
+
+java_repositories()
+
+http_archive(
+    name = "io_bazel_rules_scala",
+    sha256 = "6c69597f373a01989b9f7119bd5d28cffc9cc35d44d1f6440c409d8ef420057d",
+    strip_prefix = "rules_scala-da5ba6d97a1abdadef89d509b30a9dcfde7ffbe4",
+    urls = [
+        "https://github.com/bazelbuild/rules_scala/archive/da5ba6d97a1abdadef89d509b30a9dcfde7ffbe4.tar.gz",
     ],
 )
 
-platform_http_file(
-    name = "org_chromium_chromedriver",
-    licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-    amd64_sha256 =
-        "71eafe087900dbca4bc0b354a1d172df48b31a4a502e21f7c7b156d7e76c95c7",
-    amd64_urls = [
-        "https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip",
-    ],
-    macos_sha256 =
-        "fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae",
-    macos_urls = [
-        "https://chromedriver.storage.googleapis.com/2.41/chromedriver_mac64.zip",
-    ],
-    windows_sha256 =
-        "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",
-    windows_urls = [
-        "https://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip",
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+
+scala_repositories()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+
+scala_register_toolchains()
+```
+
+### Python
+
+```bzl
+load("@io_bazel_rules_webtesting//web:py_repositories.bzl", "py_repositories")
+
+py_repositories()
+```
+
+### Go
+
+```bzl
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "b7a62250a3a73277ade0ce306d22f122365b513f5402222403e507f2f997d421",
+    urls = [
+        "https://github.com/bazelbuild/rules_go/releases/download/0.16.3/rules_go-0.16.3.tar.gz",
     ],
 )
 
-platform_http_file(
-    name = "org_mozilla_firefox",
-    licenses = ["reciprocal"],  # MPL 2.0
-    amd64_sha256 =
-        "3a729ddcb1e0f5d63933177a35177ac6172f12edbf9fbbbf45305f49333608de",
-    amd64_urls = [
-        "https://mirror.bazel.build/ftp.mozilla.org/pub/firefox/releases/61.0.2/linux-x86_64/en-US/firefox-61.0.2.tar.bz2",
-        "https://ftp.mozilla.org/pub/firefox/releases/61.0.2/linux-x86_64/en-US/firefox-61.0.2.tar.bz2",
-    ],
-    macos_sha256 =
-        "bf23f659ae34832605dd0576affcca060d1077b7bf7395bc9874f62b84936dc5",
-    macos_urls = [
-        "https://mirror.bazel.build/ftp.mozilla.org/pub/firefox/releases/61.0.2/mac/en-US/Firefox%2061.0.2.dmg",
-        "https://ftp.mozilla.org/pub/firefox/releases/61.0.2/mac/en-US/Firefox%2061.0.2.dmg",
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
+    urls = [
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz",
     ],
 )
 
-platform_http_file(
-    name = "org_mozilla_geckodriver",
-    licenses = ["reciprocal"],  # MPL 2.0
-    amd64_sha256 =
-        "c9ae92348cf00aa719be6337a608fae8304691a95668e8e338d92623ba9e0ec6",
-    amd64_urls = [
-        "https://mirror.bazel.build/github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz",
-        "https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz",
-    ],
-    macos_sha256 =
-        "ce4a3e9d706db94e8760988de1ad562630412fa8cf898819572522be584f01ce",
-    macos_urls = [
-        "https://mirror.bazel.build/github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-macos.tar.gz",
-        "https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-macos.tar.gz",
-    ],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+load("@io_bazel_rules_webtesting//web:go_repositories.bzl", "go_repositories")
+
+go_repositories()
 ```
 
 ## Write your tests
@@ -118,7 +117,7 @@ platform_http_file(
 Write your test in the language of your choice, but use our provided Browser API
 to get an instance of WebDriver.
 
-Example Test (Java):
+### Example Java Test
 
 ```java
 import com.google.testing.web.WebTest;
@@ -147,7 +146,30 @@ public class BrowserTest {
 }
 ```
 
-Example Test (Go):
+### Example Python Test
+
+```python
+import unittest
+from testing.web import webtest
+
+
+class BrowserTest(unittest.TestCase):
+  def setUp(self):
+    self.driver = webtest.new_webdriver_session()
+
+  def tearDown(self):
+    try:
+      self.driver.quit()
+    finally:
+      self.driver = None
+
+  # Your tests here
+
+if __name__ == "__main__":
+  unittest.main()
+```
+
+### Example Go Test
 
 ```go
 import (
@@ -171,28 +193,7 @@ func TestWebApp(t *testing.T) {
 }
 ```
 
-Example Test (Python):
-
-```python
-import unittest
-from testing.web import webtest
-
-
-class BrowserTest(unittest.TestCase):
-  def setUp(self):
-    self.driver = webtest.new_webdriver_session()
-
-  def tearDown(self):
-    try:
-      self.driver.quit()
-    finally:
-      self.driver = None
-
-  # Your tests here
-
-if __name__ == "__main__":
-  unittest.main()
-```
+### BUILD file
 
 In your BUILD files, load the correct language specific build rule and create a
 test target using it:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,6 +71,20 @@ browser_repositories(
     sauce = True,
 )
 
+load("//web:go_repositories.bzl", "go_repositories", "go_internal_repositories")
+
+go_repositories()
+
+go_internal_repositories()
+
+load("//web:java_repositories.bzl", "java_repositories")
+
+java_repositories()
+
+load("//web:py_repositories.bzl", "py_repositories")
+
+py_repositories()
+
 http_archive(
     name = "io_bazel_rules_scala",
     sha256 = "6c69597f373a01989b9f7119bd5d28cffc9cc35d44d1f6440c409d8ef420057d",

--- a/build_files/metadata.BUILD
+++ b/build_files/metadata.BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +14,16 @@
 #
 ################################################################################
 #
-package(
-    default_testonly = True,
-    default_visibility = ["//:__subpackages__"],
-)
+package(default_testonly = True)
 
-config_setting(
-    name = "mac",
-    values = {"cpu": "darwin"},
-)
+licenses(["notice"])  # Apache 2.0
 
-config_setting(
-    name = "linux",
-    values = {"cpu": "k8"},
-)
-
-config_setting(
-    name = "windows",
-    values = {"cpu": "x64_windows"},
+alias(
+    name = "main",
+    actual  = select({
+        "//common/conditions:linux": "linux_amd64_stripped/main",
+        "//common/conditions:mac": "darwin_amd64_pure_stripped/main",
+        "//common/conditions:windows": "windows_amd64_pure_stripped/main.exe",
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/build_files/wsl.BUILD
+++ b/build_files/wsl.BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +14,19 @@
 #
 ################################################################################
 #
-package(
-    default_testonly = True,
-    default_visibility = ["//:__subpackages__"],
-)
+load("//web:web.bzl", "web_test_named_executable")
 
-config_setting(
-    name = "mac",
-    values = {"cpu": "darwin"},
-)
+package(default_testonly = True)
 
-config_setting(
-    name = "linux",
-    values = {"cpu": "k8"},
-)
+licenses(["notice"])  # Apache 2.0
 
-config_setting(
-    name = "windows",
-    values = {"cpu": "x64_windows"},
+web_test_named_executable(
+    name = "wsl",
+    alt_name = "WEBDRIVER_SERVER_LIGHT",
+    executable = select({
+        "//common/conditions:linux": "main/linux_amd64_stripped/main",
+        "//common/conditions:mac": "main/darwin_amd64_pure_stripped/main",
+        "//common/conditions:windows": "main/windows_amd64_pure_stripped/main.exe",
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/build_files/wtl.BUILD
+++ b/build_files/wtl.BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +14,16 @@
 #
 ################################################################################
 #
-package(
-    default_testonly = True,
-    default_visibility = ["//:__subpackages__"],
-)
+package(default_testonly = True)
 
-config_setting(
-    name = "mac",
-    values = {"cpu": "darwin"},
-)
+licenses(["notice"])  # Apache 2.0
 
-config_setting(
-    name = "linux",
-    values = {"cpu": "k8"},
-)
-
-config_setting(
-    name = "windows",
-    values = {"cpu": "x64_windows"},
+alias(
+    name = "main",
+    actual  = select({
+        "//common/conditions:linux": "linux_amd64_stripped/main",
+        "//common/conditions:mac": "darwin_amd64_pure_stripped/main",
+        "//common/conditions:windows": "windows_amd64_pure_stripped/main.exe",
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/tools/copy.bara.sky
+++ b/tools/copy.bara.sky
@@ -1,0 +1,45 @@
+core.workflow(
+	name = "release",
+	origin = folder.origin(materialize_outside_symlinks=True),
+	destination = folder.destination(),
+	authoring = authoring.pass_thru("Marc Fisher <fisherii@google.com>"),
+	origin_files = glob(
+		[
+			# Source paths to include
+			"*",
+			"browsers/**",
+			"build_files/**",
+			"common/**",
+			"go/bazel/**",
+			"go/cmdhelper/**",
+			"go/metadata/**",
+			"go/portpicker/**",
+			"go/screenshotter/**",
+			"go/webtest/**",
+			"java/**",
+			"javatests/**",
+			"scalatests/**",
+			"testdata/**",
+			"testing/**",
+			"third_party/**",
+			"web/**",
+
+			# binaries to include
+			"bazel-bin/go/metadata/main/*/main",
+			"bazel-bin/go/metadata/main/*/main.exe",		
+			"bazel-bin/go/wsl/main/*/main",
+			"bazel-bin/go/wsl/main/*/main.exe",		
+			"bazel-bin/go/wtl/main/*/main",
+			"bazel-bin/go/wtl/main/*/main.exe",		
+		],
+		exclude = ["go/metadata/main/**"],
+	),
+	transformations = [
+		core.move("bazel-bin/go/metadata/main", "go/metadata/main"),
+		core.move("bazel-bin/go/wsl", "go/wsl"),
+		core.move("bazel-bin/go/wtl", "go/wtl"),
+		core.move("build_files/metadata.BUILD", "go/metadata/main/BUILD.bazel"),
+		core.move("build_files/wsl.BUILD", "go/wsl/BUILD.bazel"),
+		core.move("build_files/wtl.BUILD", "go/wtl/main/BUILD.bazel"),
+	],
+)

--- a/tools/releaser.sh
+++ b/tools/releaser.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+bazel build -c opt --stamp \
+	--platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 \
+	//go/metadata/main \
+	//go/wsl/main \
+	//go/wtl/main
+
+bazel build -c opt --stamp \
+	--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+	//go/metadata/main \
+	//go/wsl/main \
+	//go/wtl/main
+
+bazel build -c opt --stamp \
+	--platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 \
+	//go/metadata/main \
+	//go/wsl/main \
+	//go/wtl/main	
+
+ /google/data/ro/teams/copybara/copybara --folder-dir="$1" migrate tools/copy.bara.sky release .

--- a/web/go_repositories.bzl
+++ b/web/go_repositories.bzl
@@ -1,0 +1,119 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines external repositories needed by rules_webtesting."""
+
+load(":repositories.bzl", "should_create_repository")
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def go_repositories(**kwargs):
+    """Defines external repositories required to use Go webtest and screenshotter APIs.
+
+    This function exists for other Bazel projects to call from their WORKSPACE
+    file when depending on rules_webtesting using http_archive. This function
+    makes it easy to import these transitive dependencies into the parent
+    workspace. This will check to see if a repository has been previously defined
+    before defining a new repository.
+
+    Alternatively, individual dependencies may be excluded with an
+    "omit_" + name parameter. This is useful for users who want to be rigorous
+    about declaring their own direct dependencies, or when another Bazel project
+    is depended upon (e.g. rules_closure) that defines the same dependencies as
+    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    used by calling the individual functions this method references.
+
+    Please note that while these dependencies are defined, they are not actually
+    downloaded, unless a target is built that depends on them.
+
+    Args:
+        **kwargs: omit_... parameters used to prevent importing specific
+          dependencies.
+    """
+    if should_create_repository("com_github_blang_semver", kwargs):
+        com_github_blang_semver()
+    if should_create_repository("com_github_tebeka_selenium", kwargs):
+        com_github_tebeka_selenium()
+    if kwargs.keys():
+        print("The following parameters are unknown: " + str(kwargs.keys()))
+
+def go_internal_repositories(**kwargs):
+    """Defines external repositories required to build WebTesting rules release.
+
+    Alternatively, individual dependencies may be excluded with an
+    "omit_" + name parameter. This is useful for users who want to be rigorous
+    about declaring their own direct dependencies, or when another Bazel project
+    is depended upon (e.g. rules_closure) that defines the same dependencies as
+    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    used by calling the individual functions this method references.
+
+    Please note that while these dependencies are defined, they are not actually
+    downloaded, unless a target is built that depends on them.
+
+    Args:
+        **kwargs: omit_... parameters used to prevent importing specific
+          dependencies.
+    """
+    if should_create_repository("com_github_gorilla_context", kwargs):
+        com_github_gorilla_context()
+    if should_create_repository("com_github_gorilla_mux", kwargs):
+        com_github_gorilla_mux()
+    if kwargs.keys():
+        print("The following parameters are unknown: " + str(kwargs.keys()))
+
+def com_github_blang_semver():
+    go_repository(
+        name = "com_github_blang_semver",
+        importpath = "github.com/blang/semver",
+        sha256 = "3d9da53f4c2d3169bfa9b25f2f36f301a37556a47259c870881524c643c69c57",
+        strip_prefix = "semver-3.5.1",
+        urls = [
+            "https://mirror.bazel.build/github.com/blang/semver/archive/v3.5.1.tar.gz",
+            "https://github.com/blang/semver/archive/v3.5.1.tar.gz",
+        ],
+    )
+
+def com_github_gorilla_context():
+    go_repository(
+        name = "com_github_gorilla_context",
+        importpath = "github.com/gorilla/context",
+        sha256 = "2dfdd051c238695bf9ebfed0bf6a8c533507ac0893bce23be5930e973736bb03",
+        strip_prefix = "context-1.1.1",
+        urls = [
+            "https://mirror.bazel.build/github.com/gorilla/context/archive/v1.1.1.tar.gz",
+            "https://github.com/gorilla/context/archive/v1.1.1.tar.gz",
+        ],
+    )
+
+def com_github_gorilla_mux():
+    go_repository(
+        name = "com_github_gorilla_mux",
+        importpath = "github.com/gorilla/mux",
+        sha256 = "0dc18fb09413efea7393e9c2bd8b5b442ce08e729058f5f7e328d912c6c3d3e3",
+        strip_prefix = "mux-1.6.2",
+        urls = [
+            "https://mirror.bazel.build/github.com/gorilla/mux/archive/v1.6.2.tar.gz",
+            "https://github.com/gorilla/mux/archive/v1.6.2.tar.gz",
+        ],
+    )
+
+def com_github_tebeka_selenium():
+    go_repository(
+        name = "com_github_tebeka_selenium",
+        importpath = "github.com/tebeka/selenium",
+        sha256 = "4f0e1b9f54825580707fca637a4b174872dce5da6685c010b98eff45c1b3064a",
+        strip_prefix = "selenium-edf31bb7fd715ad505d9190f8d65d13f39a7c825",
+        urls = [
+            "https://mirror.bazel.build/github.com/tebeka/selenium/archive/edf31bb7fd715ad505d9190f8d65d13f39a7c825.tar.gz",
+            "https://github.com/tebeka/selenium/archive/edf31bb7fd715ad505d9190f8d65d13f39a7c825.tar.gz",
+        ],
+    )

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -66,10 +66,11 @@ browser = rule(
             doc = "Map of execution requirements for this browser.",
         ),
         "merger": attr.label(
-            doc = "Metadata merger executable.",
+            doc = "The metadata merger binary.",
             default = Label("//go/metadata/main"),
-            executable = True,
+            allow_files = True,
             cfg = "host",
+            executable = True,
         ),
         "metadata": attr.label(
             doc = "The web_test metadata file that defines how this browser is " +

--- a/web/internal/custom_browser.bzl
+++ b/web/internal/custom_browser.bzl
@@ -84,10 +84,11 @@ custom_browser = rule(
             allow_single_file = True,
         ),
         "merger": attr.label(
-            doc = "Metadata merger executable.",
+            doc = "The metadata merger binary.",
             default = Label("//go/metadata/main"),
-            executable = True,
+            allow_files = True,
             cfg = "host",
+            executable = True,
         ),
         "environment": attr.string_dict(doc = "Map of environment variables-values to set."),
     },

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -156,12 +156,14 @@ web_test = rule(
         ),
         "launcher": attr.label(
             doc = "The web test launcher binary.",
+            allow_files = True,
             cfg = "target",
             executable = True,
         ),
         "merger": attr.label(
             doc = "The metadata merger binary.",
             default = Label("//go/metadata/main"),
+            allow_files = True,
             cfg = "host",
             executable = True,
         ),

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -59,10 +59,11 @@ web_test_config = rule(
             providers = [WebTestInfo],
         ),
         "merger": attr.label(
-            doc = "Metadata merger executable.",
-            executable = True,
-            cfg = "host",
+            doc = "The metadata merger binary.",
             default = Label("//go/metadata/main"),
+            allow_files = True,
+            cfg = "host",
+            executable = True,
         ),
         "metadata": attr.label(
             doc = "A web_test metadata file.",

--- a/web/internal/web_test_files.bzl
+++ b/web/internal/web_test_files.bzl
@@ -52,12 +52,6 @@ def _web_test_files_impl(ctx):
 
 web_test_files = rule(
     attrs = {
-        "merger": attr.label(
-            doc = "Metadata merger executable.",
-            executable = True,
-            cfg = "host",
-            default = Label("//go/metadata/main"),
-        ),
         "files": attr.label_keyed_string_dict(
             doc = "A map of files to names.",
             mandatory = True,

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -51,12 +51,6 @@ web_test_named_executable = rule(
             cfg = "target",
             mandatory = True,
         ),
-        "merger": attr.label(
-            doc = "Metadata merger executable.",
-            executable = True,
-            cfg = "host",
-            default = Label("//go/metadata/main"),
-        ),
     },
     doc = "Defines an executable that can be located by name.",
     outputs = {"web_test_metadata": "%{name}.gen.json"},

--- a/web/java_repositories.bzl
+++ b/web/java_repositories.bzl
@@ -1,0 +1,248 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines external repositories needed by rules_webtesting."""
+
+load(":repositories.bzl", "should_create_repository")
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+
+def java_repositories(**kwargs):
+    """Defines external repositories required to use Java webtest and screenshotter APIs.
+
+    This function exists for other Bazel projects to call from their WORKSPACE
+    file when depending on rules_webtesting using http_archive. This function
+    makes it easy to import these transitive dependencies into the parent
+    workspace. This will check to see if a repository has been previously defined
+    before defining a new repository.
+
+    Alternatively, individual dependencies may be excluded with an
+    "omit_" + name parameter. This is useful for users who want to be rigorous
+    about declaring their own direct dependencies, or when another Bazel project
+    is depended upon (e.g. rules_closure) that defines the same dependencies as
+    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    used by calling the individual functions this method references.
+
+    Please note that while these dependencies are defined, they are not actually
+    downloaded, unless a target is built that depends on them.
+
+    Args:
+        **kwargs: omit_... parameters used to prevent importing specific
+          dependencies.
+    """
+    if should_create_repository("com_google_code_findbugs_jsr305", kwargs):
+        com_google_code_findbugs_jsr305()
+    if should_create_repository(
+        "com_google_errorprone_error_prone_annotations",
+        kwargs,
+    ):
+        com_google_errorprone_error_prone_annotations()
+    if should_create_repository("com_google_guava", kwargs):
+        com_google_guava()
+    if should_create_repository("com_squareup_okhttp3_okhttp", kwargs):
+        com_squareup_okhttp3_okhttp()
+    if should_create_repository("com_squareup_okio", kwargs):
+        com_squareup_okio()
+    if should_create_repository("junit", kwargs):
+        junit()
+    if should_create_repository("net_bytebuddy", kwargs):
+        net_bytebuddy()
+    if should_create_repository("org_apache_commons_exec", kwargs):
+        org_apache_commons_exec()
+    if should_create_repository("org_hamcrest_core", kwargs):
+        org_hamcrest_core()
+    if should_create_repository("org_jetbrains_kotlin_stdlib", kwargs):
+        org_jetbrains_kotlin_stdlib()
+    if should_create_repository("org_json", kwargs):
+        org_json()
+    if should_create_repository("org_seleniumhq_selenium_api", kwargs):
+        org_seleniumhq_selenium_api()
+    if should_create_repository("org_seleniumhq_selenium_remote_driver", kwargs):
+        org_seleniumhq_selenium_remote_driver()
+    if kwargs.keys():
+        print("The following parameters are unknown: " + str(kwargs.keys()))
+
+def com_google_code_findbugs_jsr305():
+    java_import_external(
+        name = "com_google_code_findbugs_jsr305",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+            "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        ],
+        jar_sha256 =
+            "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        licenses = ["notice"],  # BSD 3-clause
+    )
+
+def com_google_errorprone_error_prone_annotations():
+    java_import_external(
+        name = "com_google_errorprone_error_prone_annotations",
+        jar_sha256 =
+            "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.jar",
+            "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.jar",
+        ],
+        licenses = ["notice"],  # Apache 2.0
+    )
+
+def com_google_guava():
+    java_import_external(
+        name = "com_google_guava",
+        jar_sha256 = "63b09db6861011e7fb2481be7790c7fd4b03f0bb884b3de2ecba8823ad19bf3f",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+            "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
+        ],
+        licenses = ["notice"],  # Apache 2.0
+        exports = [
+            "@com_google_code_findbugs_jsr305",
+            "@com_google_errorprone_error_prone_annotations",
+        ],
+    )
+
+def com_squareup_okhttp3_okhttp():
+    java_import_external(
+        name = "com_squareup_okhttp3_okhttp",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
+            "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
+        ],
+        jar_sha256 =
+            "a0d01017a42bba26e507fc6d448bb36e536f4b6e612f7c42de30bbdac2b7785e",
+        licenses = ["notice"],  # Apache 2.0
+        deps = [
+            "@com_squareup_okio",
+            "@com_google_code_findbugs_jsr305",
+        ],
+    )
+
+def com_squareup_okio():
+    java_import_external(
+        name = "com_squareup_okio",
+        jar_sha256 = "6773b78e61ed63b9dbb36c87f11873883f2cc3539c8be2a9568091248d83b2a2",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/squareup/okio/okio/2.1.0/okio-2.1.0.jar",
+            "https://repo1.maven.org/maven2/com/squareup/okio/okio/2.1.0/okio-2.1.0.jar",
+        ],
+        licenses = ["notice"],  # Apache 2.0
+        deps = [
+            "@com_google_code_findbugs_jsr305",
+            "@org_jetbrains_kotlin_stdlib",
+        ],
+    )
+
+def junit():
+    java_import_external(
+        name = "junit",
+        jar_sha256 =
+            "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
+            "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
+        ],
+        licenses = ["reciprocal"],  # Eclipse Public License 1.0
+        testonly_ = 1,
+        deps = ["@org_hamcrest_core"],
+    )
+
+def net_bytebuddy():
+    java_import_external(
+        name = "net_bytebuddy",
+        jar_sha256 = "4b87ad52a8f64a1197508e176e84076584160e3d65229ff757efee870cd4a8e2",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.19/byte-buddy-1.8.19.jar",
+            "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.19/byte-buddy-1.8.19.jar",
+        ],
+        licenses = ["notice"],  # Apache 2.0
+        deps = ["@com_google_code_findbugs_jsr305"],
+    )
+
+def org_apache_commons_exec():
+    java_import_external(
+        name = "org_apache_commons_exec",
+        jar_sha256 =
+            "cb49812dc1bfb0ea4f20f398bcae1a88c6406e213e67f7524fb10d4f8ad9347b",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
+            "https://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
+        ],
+        licenses = ["notice"],  # Apache License, Version 2.0
+    )
+
+def org_hamcrest_core():
+    java_import_external(
+        name = "org_hamcrest_core",
+        jar_sha256 =
+            "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+        ],
+        licenses = ["notice"],  # New BSD License
+        testonly_ = 1,
+    )
+
+def org_jetbrains_kotlin_stdlib():
+    java_import_external(
+        name = "org_jetbrains_kotlin_stdlib",
+        jar_sha256 = "4ff0fcb97f4983b4aaba12668c24ad21b08460915db1b021d8f1d8bee687f21c",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.0/kotlin-stdlib-1.3.0.jar",
+            "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.0/kotlin-stdlib-1.3.0.jar",
+        ],
+        licenses = ["notice"],  # The Apache Software License, Version 2.0
+    )
+
+def org_json():
+    java_import_external(
+        name = "org_json",
+        jar_sha256 = "518080049ba83181914419d11a25d9bc9833a2d729b6a6e7469fa52851356da8",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/json/json/20180813/json-20180813.jar",
+            "https://repo1.maven.org/maven2/org/json/json/20180813/json-20180813.jar",
+        ],
+        licenses = ["notice"],  # MIT-style license
+    )
+
+def org_seleniumhq_selenium_api():
+    java_import_external(
+        name = "org_seleniumhq_selenium_api",
+        jar_sha256 = "c9d8907216650cffac1526fa40caab840ae6fdbe901ce3d4576a435d54dd41fa",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.5/selenium-api-3.141.5.jar",
+            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.5/selenium-api-3.141.5.jar",
+        ],
+        licenses = ["notice"],  # The Apache Software License, Version 2.0
+        testonly_ = 1,
+    )
+
+def org_seleniumhq_selenium_remote_driver():
+    java_import_external(
+        name = "org_seleniumhq_selenium_remote_driver",
+        jar_sha256 =
+            "fe144c413fba8dcf5dc490cfd063588758b2ac8a960e3d2117b06f28a16d04b5",
+        jar_urls = [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.5/selenium-remote-driver-3.141.5.jar",
+            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.5/selenium-remote-driver-3.141.5.jar",
+        ],
+        licenses = ["notice"],  # The Apache Software License, Version 2.0
+        testonly_ = 1,
+        deps = [
+            "@com_google_guava",
+            "@net_bytebuddy",
+            "@com_squareup_okhttp3_okhttp",
+            "@com_squareup_okio",
+            "@org_apache_commons_exec",
+            "@org_seleniumhq_selenium_api",
+        ],
+    )

--- a/web/py_repositories.bzl
+++ b/web/py_repositories.bzl
@@ -1,0 +1,69 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines external repositories needed by rules_webtesting."""
+
+load(":repositories.bzl", "should_create_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def py_repositories(**kwargs):
+    """Defines external repositories required to use Python webtest and screenshotter APIs.
+
+    This function exists for other Bazel projects to call from their WORKSPACE
+    file when depending on rules_webtesting using http_archive. This function
+    makes it easy to import these transitive dependencies into the parent
+    workspace. This will check to see if a repository has been previously defined
+    before defining a new repository.
+
+    Alternatively, individual dependencies may be excluded with an
+    "omit_" + name parameter. This is useful for users who want to be rigorous
+    about declaring their own direct dependencies, or when another Bazel project
+    is depended upon (e.g. rules_closure) that defines the same dependencies as
+    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    used by calling the individual functions this method references.
+
+    Please note that while these dependencies are defined, they are not actually
+    downloaded, unless a target is built that depends on them.
+
+    Args:
+        **kwargs: omit_... parameters used to prevent importing specific
+          dependencies.
+    """
+    if should_create_repository("com_github_urllib3", kwargs):
+        com_github_urllib3()
+    if should_create_repository("org_seleniumhq_py", kwargs):
+        org_seleniumhq_py()
+    if kwargs.keys():
+        print("The following parameters are unknown: " + str(kwargs.keys()))
+
+def com_github_urllib3():
+    http_archive(
+        name = "com_github_urllib3",
+        build_file = str(Label("//build_files:com_github_urllib3.BUILD")),
+        sha256 = "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22",
+        strip_prefix = "urllib3-1.24.1",
+        urls = [
+            "https://files.pythonhosted.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
+        ],
+    )
+
+def org_seleniumhq_py():
+    http_archive(
+        name = "org_seleniumhq_py",
+        build_file = str(Label("//build_files:org_seleniumhq_py.BUILD")),
+        sha256 = "deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d",
+        strip_prefix = "selenium-3.141.0",
+        urls = [
+            "https://files.pythonhosted.org/packages/ed/9c/9030520bf6ff0b4c98988448a93c04fcbd5b13cd9520074d8ed53569ccfe/selenium-3.141.0.tar.gz",
+        ],
+    )

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -14,17 +14,10 @@
 """Defines external repositories needed by rules_webtesting."""
 
 load("//web/internal:platform_http_file.bzl", "platform_http_file")
-load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-
-# NOTE: URLs are mirrored by an asynchronous review process. They must
-#       be greppable for that to happen. It's OK to submit broken mirror
-#       URLs, so long as they're correctly formatted. Bazel's downloader
-#       has fast failover.
 
 def web_test_repositories(**kwargs):
-    """Defines external repositories required by Webtesting Rules.
+    """Defines external repositories required by WebTesting Rules.
 
     This function exists for other Bazel projects to call from their WORKSPACE
     file when depending on rules_webtesting using http_archive. This function
@@ -48,62 +41,17 @@ def web_test_repositories(**kwargs):
     """
     if should_create_repository("bazel_skylib", kwargs):
         bazel_skylib()
-    if should_create_repository("com_github_blang_semver", kwargs):
-        com_github_blang_semver()
-    if should_create_repository("com_github_gorilla_context", kwargs):
-        com_github_gorilla_context()
-    if should_create_repository("com_github_gorilla_mux", kwargs):
-        com_github_gorilla_mux()
-    if should_create_repository("com_github_tebeka_selenium", kwargs):
-        com_github_tebeka_selenium()
-    if should_create_repository("com_github_urllib3", kwargs):
-        com_github_urllib3()
-    if should_create_repository("com_google_code_findbugs_jsr305", kwargs):
-        com_google_code_findbugs_jsr305()
-    if should_create_repository(
-        "com_google_errorprone_error_prone_annotations",
-        kwargs,
-    ):
-        com_google_errorprone_error_prone_annotations()
-    if should_create_repository("com_google_guava", kwargs):
-        com_google_guava()
-    if should_create_repository("com_squareup_okhttp3_okhttp", kwargs):
-        com_squareup_okhttp3_okhttp()
-    if should_create_repository("com_squareup_okio", kwargs):
-        com_squareup_okio()
-    if should_create_repository("junit", kwargs):
-        junit()
-    if should_create_repository("net_bytebuddy", kwargs):
-        net_bytebuddy()
-    if should_create_repository("org_apache_commons_exec", kwargs):
-        org_apache_commons_exec()
-    if should_create_repository("org_hamcrest_core", kwargs):
-        org_hamcrest_core()
-    if should_create_repository("org_jetbrains_kotlin_stdlib", kwargs):
-        org_jetbrains_kotlin_stdlib()
-    if should_create_repository("org_json", kwargs):
-        org_json()
-    if should_create_repository("org_seleniumhq_py", kwargs):
-        org_seleniumhq_py()
-    if should_create_repository("org_seleniumhq_selenium_api", kwargs):
-        org_seleniumhq_selenium_api()
-    if should_create_repository("org_seleniumhq_selenium_remote_driver", kwargs):
-        org_seleniumhq_selenium_remote_driver()
     if kwargs.keys():
         print("The following parameters are unknown: " + str(kwargs.keys()))
 
 def should_create_repository(name, args):
     """Returns whether the name repository should be created.
-
     This allows creation of a repository to be disabled by either an
     "omit_" _+ name parameter or by previously defining a rule for the repository.
-
     The args dict will be mutated to remove "omit_" + name.
-
     Args:
         name: The name of the repository that should be checked.
         args: A dictionary that contains "omit_...": bool pairs.
-
     Returns:
         boolean indicating whether the repository should be created.
     """
@@ -147,104 +95,6 @@ def bazel_skylib():
         ],
     )
 
-def com_github_blang_semver():
-    go_repository(
-        name = "com_github_blang_semver",
-        importpath = "github.com/blang/semver",
-        sha256 = "3d9da53f4c2d3169bfa9b25f2f36f301a37556a47259c870881524c643c69c57",
-        strip_prefix = "semver-3.5.1",
-        urls = [
-            "https://mirror.bazel.build/github.com/blang/semver/archive/v3.5.1.tar.gz",
-            "https://github.com/blang/semver/archive/v3.5.1.tar.gz",
-        ],
-    )
-
-def com_github_gorilla_context():
-    go_repository(
-        name = "com_github_gorilla_context",
-        importpath = "github.com/gorilla/context",
-        sha256 = "2dfdd051c238695bf9ebfed0bf6a8c533507ac0893bce23be5930e973736bb03",
-        strip_prefix = "context-1.1.1",
-        urls = [
-            "https://mirror.bazel.build/github.com/gorilla/context/archive/v1.1.1.tar.gz",
-            "https://github.com/gorilla/context/archive/v1.1.1.tar.gz",
-        ],
-    )
-
-def com_github_gorilla_mux():
-    go_repository(
-        name = "com_github_gorilla_mux",
-        importpath = "github.com/gorilla/mux",
-        sha256 = "0dc18fb09413efea7393e9c2bd8b5b442ce08e729058f5f7e328d912c6c3d3e3",
-        strip_prefix = "mux-1.6.2",
-        urls = [
-            "https://mirror.bazel.build/github.com/gorilla/mux/archive/v1.6.2.tar.gz",
-            "https://github.com/gorilla/mux/archive/v1.6.2.tar.gz",
-        ],
-    )
-
-def com_github_tebeka_selenium():
-    go_repository(
-        name = "com_github_tebeka_selenium",
-        importpath = "github.com/tebeka/selenium",
-        sha256 = "4f0e1b9f54825580707fca637a4b174872dce5da6685c010b98eff45c1b3064a",
-        strip_prefix = "selenium-edf31bb7fd715ad505d9190f8d65d13f39a7c825",
-        urls = [
-            "https://mirror.bazel.build/github.com/tebeka/selenium/archive/edf31bb7fd715ad505d9190f8d65d13f39a7c825.tar.gz",
-            "https://github.com/tebeka/selenium/archive/edf31bb7fd715ad505d9190f8d65d13f39a7c825.tar.gz",
-        ],
-    )
-
-def com_github_urllib3():
-    http_archive(
-        name = "com_github_urllib3",
-        build_file = str(Label("//build_files:com_github_urllib3.BUILD")),
-        sha256 = "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22",
-        strip_prefix = "urllib3-1.24.1",
-        urls = [
-            "https://files.pythonhosted.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
-        ],
-    )
-
-def com_google_code_findbugs_jsr305():
-    java_import_external(
-        name = "com_google_code_findbugs_jsr305",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-            "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        ],
-        jar_sha256 =
-            "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        licenses = ["notice"],  # BSD 3-clause
-    )
-
-def com_google_errorprone_error_prone_annotations():
-    java_import_external(
-        name = "com_google_errorprone_error_prone_annotations",
-        jar_sha256 =
-            "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.jar",
-            "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.jar",
-        ],
-        licenses = ["notice"],  # Apache 2.0
-    )
-
-def com_google_guava():
-    java_import_external(
-        name = "com_google_guava",
-        jar_sha256 = "63b09db6861011e7fb2481be7790c7fd4b03f0bb884b3de2ecba8823ad19bf3f",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
-            "https://repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar",
-        ],
-        licenses = ["notice"],  # Apache 2.0
-        exports = [
-            "@com_google_code_findbugs_jsr305",
-            "@com_google_errorprone_error_prone_annotations",
-        ],
-    )
-
 def com_saucelabs_sauce_connect():
     platform_http_file(
         name = "com_saucelabs_sauce_connect",
@@ -262,75 +112,6 @@ def com_saucelabs_sauce_connect():
         windows_urls = [
             "https://saucelabs.com/downloads/sc-4.4.12-win32.zip",
         ],
-    )
-
-def com_squareup_okhttp3_okhttp():
-    java_import_external(
-        name = "com_squareup_okhttp3_okhttp",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
-            "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
-        ],
-        jar_sha256 =
-            "a0d01017a42bba26e507fc6d448bb36e536f4b6e612f7c42de30bbdac2b7785e",
-        licenses = ["notice"],  # Apache 2.0
-        deps = [
-            "@com_squareup_okio",
-            "@com_google_code_findbugs_jsr305",
-        ],
-    )
-
-def com_squareup_okio():
-    java_import_external(
-        name = "com_squareup_okio",
-        jar_sha256 = "6773b78e61ed63b9dbb36c87f11873883f2cc3539c8be2a9568091248d83b2a2",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/squareup/okio/okio/2.1.0/okio-2.1.0.jar",
-            "https://repo1.maven.org/maven2/com/squareup/okio/okio/2.1.0/okio-2.1.0.jar",
-        ],
-        licenses = ["notice"],  # Apache 2.0
-        deps = [
-            "@com_google_code_findbugs_jsr305",
-            "@org_jetbrains_kotlin_stdlib",
-        ],
-    )
-
-def junit():
-    java_import_external(
-        name = "junit",
-        jar_sha256 =
-            "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
-            "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
-        ],
-        licenses = ["reciprocal"],  # Eclipse Public License 1.0
-        testonly_ = 1,
-        deps = ["@org_hamcrest_core"],
-    )
-
-def net_bytebuddy():
-    java_import_external(
-        name = "net_bytebuddy",
-        jar_sha256 = "4b87ad52a8f64a1197508e176e84076584160e3d65229ff757efee870cd4a8e2",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.19/byte-buddy-1.8.19.jar",
-            "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.8.19/byte-buddy-1.8.19.jar",
-        ],
-        licenses = ["notice"],  # Apache 2.0
-        deps = ["@com_google_code_findbugs_jsr305"],
-    )
-
-def org_apache_commons_exec():
-    java_import_external(
-        name = "org_apache_commons_exec",
-        jar_sha256 =
-            "cb49812dc1bfb0ea4f20f398bcae1a88c6406e213e67f7524fb10d4f8ad9347b",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
-            "https://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
-        ],
-        licenses = ["notice"],  # Apache License, Version 2.0
     )
 
 def org_chromium_chromedriver():
@@ -375,41 +156,6 @@ def org_chromium_chromium():
         ],
     )
 
-def org_hamcrest_core():
-    java_import_external(
-        name = "org_hamcrest_core",
-        jar_sha256 =
-            "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
-            "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
-        ],
-        licenses = ["notice"],  # New BSD License
-        testonly_ = 1,
-    )
-
-def org_jetbrains_kotlin_stdlib():
-    java_import_external(
-        name = "org_jetbrains_kotlin_stdlib",
-        jar_sha256 = "4ff0fcb97f4983b4aaba12668c24ad21b08460915db1b021d8f1d8bee687f21c",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.0/kotlin-stdlib-1.3.0.jar",
-            "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.0/kotlin-stdlib-1.3.0.jar",
-        ],
-        licenses = ["notice"],  # The Apache Software License, Version 2.0
-    )
-
-def org_json():
-    java_import_external(
-        name = "org_json",
-        jar_sha256 = "518080049ba83181914419d11a25d9bc9833a2d729b6a6e7469fa52851356da8",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/org/json/json/20180813/json-20180813.jar",
-            "https://repo1.maven.org/maven2/org/json/json/20180813/json-20180813.jar",
-        ],
-        licenses = ["notice"],  # MIT-style license
-    )
-
 def org_mozilla_firefox():
     platform_http_file(
         name = "org_mozilla_firefox",
@@ -443,49 +189,5 @@ def org_mozilla_geckodriver():
         macos_urls = [
             "https://mirror.bazel.build/github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-macos.tar.gz",
             "https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-macos.tar.gz",
-        ],
-    )
-
-def org_seleniumhq_py():
-    http_archive(
-        name = "org_seleniumhq_py",
-        build_file = str(Label("//build_files:org_seleniumhq_py.BUILD")),
-        sha256 = "deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d",
-        strip_prefix = "selenium-3.141.0",
-        urls = [
-            "https://files.pythonhosted.org/packages/ed/9c/9030520bf6ff0b4c98988448a93c04fcbd5b13cd9520074d8ed53569ccfe/selenium-3.141.0.tar.gz",
-        ],
-    )
-
-def org_seleniumhq_selenium_api():
-    java_import_external(
-        name = "org_seleniumhq_selenium_api",
-        jar_sha256 = "c9d8907216650cffac1526fa40caab840ae6fdbe901ce3d4576a435d54dd41fa",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.5/selenium-api-3.141.5.jar",
-            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.5/selenium-api-3.141.5.jar",
-        ],
-        licenses = ["notice"],  # The Apache Software License, Version 2.0
-        testonly_ = 1,
-    )
-
-def org_seleniumhq_selenium_remote_driver():
-    java_import_external(
-        name = "org_seleniumhq_selenium_remote_driver",
-        jar_sha256 =
-            "fe144c413fba8dcf5dc490cfd063588758b2ac8a960e3d2117b06f28a16d04b5",
-        jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.5/selenium-remote-driver-3.141.5.jar",
-            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.5/selenium-remote-driver-3.141.5.jar",
-        ],
-        licenses = ["notice"],  # The Apache Software License, Version 2.0
-        testonly_ = 1,
-        deps = [
-            "@com_google_guava",
-            "@net_bytebuddy",
-            "@com_squareup_okhttp3_okhttp",
-            "@com_squareup_okio",
-            "@org_apache_commons_exec",
-            "@org_seleniumhq_selenium_api",
         ],
     )


### PR DESCRIPTION
- Add release script that creates a release version where:
  - Go binaries are precompiled
  - Most Go code is removed
- Add separate rules for loading only language-specific repositories.