### PR TITLE
Add TestStripAllPrefixedExcept, using it to strip undesired caps.

### DIFF
--- a/go/metadata/capabilities/capabilities_test.go
+++ b/go/metadata/capabilities/capabilities_test.go
@@ -1036,8 +1036,6 @@ func TestMergeOver(t *testing.T) {
 	}
 }
 
-
-
 func TestStripAllPrefixedExcept(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/go/metadata/capabilities/capabilities_test.go
+++ b/go/metadata/capabilities/capabilities_test.go
@@ -1036,6 +1036,124 @@ func TestMergeOver(t *testing.T) {
 	}
 }
 
+
+
+func TestStripAllPrefixedExcept(t *testing.T) {
+	testCases := []struct {
+		name   string
+		in     *Capabilities
+		exempt []string
+		out    *Capabilities
+	}{
+		{
+			name: "strips non-exempt AlwaysMatch prefixed capabilities",
+			in: &Capabilities{
+				AlwaysMatch: map[string]interface{}{
+					"nonexempt:cap": "val",
+				},
+			},
+			exempt: []string{""},
+			out: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+			},
+		},
+		{
+			name: "does not strip exempt AlwaysMatch prefixed capabilities",
+			in: &Capabilities{
+				AlwaysMatch: map[string]interface{}{
+					"foo:cap": "val",
+				},
+			},
+			exempt: []string{"foo"},
+			out: &Capabilities{
+				AlwaysMatch: map[string]interface{}{
+					"foo:cap": "val",
+				},
+			},
+		},
+		{
+			name: "strips non-exempt FirstMatch prefixed capabilities",
+			in: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+				FirstMatch: []map[string]interface{}{
+					{
+						"foo:cap": "val",
+					},
+				},
+			},
+			exempt: []string{""},
+			out: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+				FirstMatch:  []map[string]interface{}{map[string]interface{}{}},
+			},
+		},
+		{
+			name: "does not strip exempt FirstMatch prefixed capabilities",
+			in: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+				FirstMatch: []map[string]interface{}{
+					{
+						"foo:cap": "val",
+					},
+				},
+			},
+			exempt: []string{"foo"},
+			out: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+				FirstMatch: []map[string]interface{}{
+					{
+						"foo:cap": "val",
+					},
+				},
+			},
+		},
+		{
+			name: "does not strip FirstMatch un-prefixed capabilities",
+			in: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+				FirstMatch: []map[string]interface{}{
+					{
+						"cap": "val",
+					},
+				},
+			},
+			exempt: []string{""},
+			out: &Capabilities{
+				AlwaysMatch: map[string]interface{}{},
+				FirstMatch: []map[string]interface{}{
+					{
+						"cap": "val",
+					},
+				},
+			},
+		},
+		{
+			name: "does not strip AlwaysMatch un-prefixed capabilities",
+			in: &Capabilities{
+				AlwaysMatch: map[string]interface{}{
+					"cap": "val",
+				},
+			},
+			exempt: []string{""},
+			out: &Capabilities{
+				AlwaysMatch: map[string]interface{}{
+					"cap": "val",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tc.in.StripAllPrefixedExcept(tc.exempt...)
+
+			if !reflect.DeepEqual(out, tc.out) {
+				t.Fatalf("got %#v, want %#v", out, tc.out)
+			}
+		})
+	}
+}
+
 func TestResolve(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/go/wsl/driver/driver.go
+++ b/go/wsl/driver/driver.go
@@ -380,7 +380,7 @@ func (d *Driver) Forward(ctx context.Context, w http.ResponseWriter, r *http.Req
 func (d *Driver) NewSession(ctx context.Context, caps *capabilities.Capabilities, w http.ResponseWriter) (string, error) {
 	// IEDriver does not handle capabilities with unknown prefixes, so they must be stripped.
 	if bn, ok := caps.AlwaysMatch["browserName"].(string); ok && bn == "internet explorer" {
-		caps = caps.Strip("goog:chromeOptions", "moz:firefoxOptions")
+		caps = caps.StripAllPrefixedExcept("se")
 	}
 
 	wd, err := webdriver.CreateSession(ctx, d.Address, 1, caps.Strip("google:wslConfig", "google:sessionId"))
@@ -529,3 +529,4 @@ func (f *fakeResponseWriter) Write(b []byte) (int, error) {
 func (f *fakeResponseWriter) WriteHeader(statusCode int) {
 	log.Printf("%s status code: %d", f.prefix, statusCode)
 }
+


### PR DESCRIPTION
This saves us the trouble of manually stripping for the IE case in driver.go every time a new prefixed capability comes around.