### PR TITLE
fix: 'powershell.exe' is not recognized as an internal or external co…

### DIFF
--- a/web/internal/extract.bat
+++ b/web/internal/extract.bat
@@ -17,4 +17,4 @@
 
 :: TODO(DrMarcII): Add support for strip_prefix (%3) parameter.
 
-powershell.exe -NoP -NonI -Command "Expand-Archive '%1' '%2'"
+start /b /wait powershell.exe -NoP -NonI -Command "Expand-Archive '%1' '%2'"


### PR DESCRIPTION
…mmand, operable program or batch file.

In some cases in Windows 10, adding powershell to the PATH environment variables is not enough to get powershell running from a batch file, as it will still fail with `'powershell.exe' is not recognized as an internal or external command,
operable program or batch file.`

Based on this post https://social.technet.microsoft.com/Forums/en-US/4b4e1006-5c9f-4360-ac82-ffa880e8b75e/windows-10-powershell-is-not-recognized-as-an-internal-or-external-command-operable-program-or?forum=win10itprogeneral a workaround for this is adding `start /b` before the PS command invocation. 

Tested locally and indeed solves the issue.

//cc @meteorcloudy & @ocombe