### PR TITLE
Round up the rect's bounds when converting.

### DIFF
--- a/go/webdriver/webdriver.go
+++ b/go/webdriver/webdriver.go
@@ -122,7 +122,7 @@ type Rectangle struct {
 
 // ToImageRectangle converts webdriver.Rectangle to an image.Rectangle.
 func (r *Rectangle) ToImageRectangle() image.Rectangle {
-	return image.Rect(int(math.Round(r.X)), int(math.Round(r.Y)), int(math.Round(r.X+r.Width)), int(math.Round(r.Y+r.Height)))
+	return image.Rect(int(math.Trunc(r.X)), int(math.Trunc(r.Y)), int(math.Ceil(r.X+r.Width)), int(math.Ceil(r.Y+r.Height)))
 }
 
 // LogEntry is an entry parsed from the logs retrieved from the remote WebDriver.


### PR DESCRIPTION
Rather than purely rounding, which can lead to a rectangle that does
not encompass all of the area of the original rectangle, truncate the x1
and y1 values and get the ceiling of the x2 and y2 values. This
effectively "rounds up" the area of the rectangle, ensuring the original
area is always encompassed.