### PR TITLE
Updates java dependency names to be compatible with rules_jvm_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ load("@io_bazel_rules_webtesting//web:java_repositories.bzl", "java_repositories
 java_repositories()
 ```
 
+#### Using `rules_jvm_external`?
+
+If you're using `rules_jvm_external` to manage your dependencies, you can add the required artifacts
+directly to your `maven_install` instead of using `java_repositories`.
+
+```bzl
+load("@io_bazel_rules_webtesting//web:java_repositories.bzl", "RULES_WEBTESTING_ARTIFACTS")
+
+maven_install(
+    artifacts = [
+      # Your artifacts
+    ] + RULES_WEBTESTING_ARTIFACTS,
+    # Enabling compatability support is required.
+    generate_compat_repositories = True,
+)
+```
+
 ### Scala
 
 ```bzl

--- a/java/com/google/testing/bazel/BUILD.bazel
+++ b/java/com/google/testing/bazel/BUILD.bazel
@@ -20,5 +20,5 @@ java_library(
     name = "bazel",
     srcs = glob(["*.java"]),
     visibility = ["//visibility:public"],
-    deps = ["@com_google_guava"],
+    deps = ["@com_google_guava_guava"],
 )

--- a/java/com/google/testing/web/BUILD.bazel
+++ b/java/com/google/testing/web/BUILD.bazel
@@ -22,7 +22,7 @@ java_library(
     srcs = glob(["*.java"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@org_seleniumhq_selenium_api",
-        "@org_seleniumhq_selenium_remote_driver",
+        "@org_seleniumhq_selenium_selenium_api",
+        "@org_seleniumhq_selenium_selenium_remote_driver",
     ],
 )

--- a/javatests/com/google/testing/web/BUILD.bazel
+++ b/javatests/com/google/testing/web/BUILD.bazel
@@ -32,7 +32,7 @@ java_web_test_suite(
     },
     deps = [
         "//java/com/google/testing/web",
-        "@junit",
-        "@org_seleniumhq_selenium_api",
+        "@junit_junit",
+        "@org_seleniumhq_selenium_selenium_api",
     ],
 )

--- a/scalatests/com/google/testing/web/BUILD.bazel
+++ b/scalatests/com/google/testing/web/BUILD.bazel
@@ -32,7 +32,7 @@ scala_web_test_suite(
     },
     deps = [
         "//java/com/google/testing/web",
-        "@junit",
-        "@org_seleniumhq_selenium_api",
+        "@junit_junit",
+        "@org_seleniumhq_selenium_selenium_api",
     ],
 )

--- a/web/go_repositories.bzl
+++ b/web/go_repositories.bzl
@@ -29,7 +29,7 @@ def go_repositories(**kwargs):
     "omit_" + name parameter. This is useful for users who want to be rigorous
     about declaring their own direct dependencies, or when another Bazel project
     is depended upon (e.g. rules_closure) that defines the same dependencies as
-    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    this one (e.g. com_google_guava_guava.) Alternatively, a whitelist model may be
     used by calling the individual functions this method references.
 
     Please note that while these dependencies are defined, they are not actually
@@ -53,7 +53,7 @@ def go_internal_repositories(**kwargs):
     "omit_" + name parameter. This is useful for users who want to be rigorous
     about declaring their own direct dependencies, or when another Bazel project
     is depended upon (e.g. rules_closure) that defines the same dependencies as
-    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    this one (e.g. com_google_guava_guava.) Alternatively, a whitelist model may be
     used by calling the individual functions this method references.
 
     Please note that while these dependencies are defined, they are not actually

--- a/web/java_repositories.bzl
+++ b/web/java_repositories.bzl
@@ -29,7 +29,7 @@ def java_repositories(**kwargs):
     "omit_" + name parameter. This is useful for users who want to be rigorous
     about declaring their own direct dependencies, or when another Bazel project
     is depended upon (e.g. rules_closure) that defines the same dependencies as
-    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    this one (e.g. com_google_guava_guava.) Alternatively, a whitelist model may be
     used by calling the individual functions this method references.
 
     Please note that while these dependencies are defined, they are not actually
@@ -46,28 +46,28 @@ def java_repositories(**kwargs):
         kwargs,
     ):
         com_google_errorprone_error_prone_annotations()
-    if should_create_repository("com_google_guava", kwargs):
-        com_google_guava()
+    if should_create_repository("com_google_guava_guava", kwargs):
+        com_google_guava_guava()
     if should_create_repository("com_squareup_okhttp3_okhttp", kwargs):
         com_squareup_okhttp3_okhttp()
-    if should_create_repository("com_squareup_okio", kwargs):
-        com_squareup_okio()
-    if should_create_repository("junit", kwargs):
+    if should_create_repository("com_squareup_okio_okio", kwargs):
+        com_squareup_okio_okio()
+    if should_create_repository("junit_junit", kwargs):
         junit()
-    if should_create_repository("net_bytebuddy", kwargs):
-        net_bytebuddy()
-    if should_create_repository("org_apache_commons_exec", kwargs):
-        org_apache_commons_exec()
-    if should_create_repository("org_hamcrest_core", kwargs):
-        org_hamcrest_core()
-    if should_create_repository("org_jetbrains_kotlin_stdlib", kwargs):
-        org_jetbrains_kotlin_stdlib()
-    if should_create_repository("org_json", kwargs):
-        org_json()
-    if should_create_repository("org_seleniumhq_selenium_api", kwargs):
-        org_seleniumhq_selenium_api()
-    if should_create_repository("org_seleniumhq_selenium_remote_driver", kwargs):
-        org_seleniumhq_selenium_remote_driver()
+    if should_create_repository("net_bytebuddy_byte_buddy", kwargs):
+        net_bytebuddy_byte_buddy()
+    if should_create_repository("org_apache_commons_commons_exec", kwargs):
+        org_apache_commons_commons_exec()
+    if should_create_repository("org_hamcrest_hamcrest_core", kwargs):
+        org_hamcrest_hamcrest_core()
+    if should_create_repository("org_jetbrains_kotlin_kotlin_stdlib", kwargs):
+        org_jetbrains_kotlin_kotlin_stdlib()
+    if should_create_repository("org_json_json", kwargs):
+        org_json_json()
+    if should_create_repository("org_seleniumhq_selenium_selenium_api", kwargs):
+        org_seleniumhq_selenium_selenium_api()
+    if should_create_repository("org_seleniumhq_selenium_selenium_remote_driver", kwargs):
+        org_seleniumhq_selenium_selenium_remote_driver()
     if kwargs.keys():
         print("The following parameters are unknown: " + str(kwargs.keys()))
 
@@ -91,9 +91,9 @@ def com_google_errorprone_error_prone_annotations():
         licenses = ["notice"],  # Apache 2.0
     )
 
-def com_google_guava():
+def com_google_guava_guava():
     java_import_external(
-        name = "com_google_guava",
+        name = "com_google_guava_guava",
         jar_sha256 = "4a5aa70cc968a4d137e599ad37553e5cfeed2265e8c193476d7119036c536fe7",
         jar_urls = [
             "https://repo1.maven.org/maven2/com/google/guava/guava/27.1-jre/guava-27.1-jre.jar",
@@ -114,14 +114,14 @@ def com_squareup_okhttp3_okhttp():
         ],
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_squareup_okio",
+            "@com_squareup_okio_okio",
             "@com_google_code_findbugs_jsr305",
         ],
     )
 
-def com_squareup_okio():
+def com_squareup_okio_okio():
     java_import_external(
-        name = "com_squareup_okio",
+        name = "com_squareup_okio_okio",
         jar_sha256 = "e58c97406a6bb1138893750299ac63c6aa04b38b6b49eae1bfcad1a63ef9ba1b",
         jar_urls = [
             "https://repo1.maven.org/maven2/com/squareup/okio/okio/2.2.2/okio-2.2.2.jar",
@@ -129,25 +129,25 @@ def com_squareup_okio():
         licenses = ["notice"],  # Apache 2.0
         deps = [
             "@com_google_code_findbugs_jsr305",
-            "@org_jetbrains_kotlin_stdlib",
+            "@org_jetbrains_kotlin_kotlin_stdlib",
         ],
     )
 
 def junit():
     java_import_external(
-        name = "junit",
+        name = "junit_junit",
         jar_sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
         jar_urls = [
             "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
         ],
         licenses = ["reciprocal"],  # Eclipse Public License 1.0
         testonly_ = 1,
-        deps = ["@org_hamcrest_core"],
+        deps = ["@org_hamcrest_hamcrest_core"],
     )
 
-def net_bytebuddy():
+def net_bytebuddy_byte_buddy():
     java_import_external(
-        name = "net_bytebuddy",
+        name = "net_bytebuddy_byte_buddy",
         jar_sha256 = "3688c3d434bebc3edc5516296a2ed0f47b65e451071b4afecad84f902f0efc11",
         jar_urls = [
             "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.9.12/byte-buddy-1.9.12.jar",
@@ -156,9 +156,9 @@ def net_bytebuddy():
         deps = ["@com_google_code_findbugs_jsr305"],
     )
 
-def org_apache_commons_exec():
+def org_apache_commons_commons_exec():
     java_import_external(
-        name = "org_apache_commons_exec",
+        name = "org_apache_commons_commons_exec",
         jar_sha256 =
             "cb49812dc1bfb0ea4f20f398bcae1a88c6406e213e67f7524fb10d4f8ad9347b",
         jar_urls = [
@@ -167,9 +167,9 @@ def org_apache_commons_exec():
         licenses = ["notice"],  # Apache License, Version 2.0
     )
 
-def org_hamcrest_core():
+def org_hamcrest_hamcrest_core():
     java_import_external(
-        name = "org_hamcrest_core",
+        name = "org_hamcrest_hamcrest_core",
         jar_sha256 = "e09109e54a289d88506b9bfec987ddd199f4217c9464132668351b9a4f00bee9",
         jar_urls = [
             "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar",
@@ -178,9 +178,9 @@ def org_hamcrest_core():
         testonly_ = 1,
     )
 
-def org_jetbrains_kotlin_stdlib():
+def org_jetbrains_kotlin_kotlin_stdlib():
     java_import_external(
-        name = "org_jetbrains_kotlin_stdlib",
+        name = "org_jetbrains_kotlin_kotlin_stdlib",
         jar_sha256 = "f38c84326543e66ed4895b20fb3ea0fca527fd5a040e1f49d0946ecf3d2b3b23",
         jar_urls = [
             "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.31/kotlin-stdlib-1.3.31.jar",
@@ -188,9 +188,9 @@ def org_jetbrains_kotlin_stdlib():
         licenses = ["notice"],  # The Apache Software License, Version 2.0
     )
 
-def org_json():
+def org_json_json():
     java_import_external(
-        name = "org_json",
+        name = "org_json_json",
         jar_sha256 = "518080049ba83181914419d11a25d9bc9833a2d729b6a6e7469fa52851356da8",
         jar_urls = [
             "https://repo1.maven.org/maven2/org/json/json/20180813/json-20180813.jar",
@@ -198,9 +198,9 @@ def org_json():
         licenses = ["notice"],  # MIT-style license
     )
 
-def org_seleniumhq_selenium_api():
+def org_seleniumhq_selenium_selenium_api():
     java_import_external(
-        name = "org_seleniumhq_selenium_api",
+        name = "org_seleniumhq_selenium_selenium_api",
         jar_sha256 = "8bfd5a736eccfc08866301ffc9b7f529e55976355c5799bed8392486df64dee5",
         jar_urls = [
             "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.59/selenium-api-3.141.59.jar",
@@ -209,9 +209,9 @@ def org_seleniumhq_selenium_api():
         testonly_ = 1,
     )
 
-def org_seleniumhq_selenium_remote_driver():
+def org_seleniumhq_selenium_selenium_remote_driver():
     java_import_external(
-        name = "org_seleniumhq_selenium_remote_driver",
+        name = "org_seleniumhq_selenium_selenium_remote_driver",
         jar_sha256 = "9829fe57adf36743d785d0c2e7db504ba3ba0a3aacac652b8867cc854d2dfc45",
         jar_urls = [
             "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.59/selenium-remote-driver-3.141.59.jar",
@@ -219,11 +219,20 @@ def org_seleniumhq_selenium_remote_driver():
         licenses = ["notice"],  # The Apache Software License, Version 2.0
         testonly_ = 1,
         deps = [
-            "@com_google_guava",
-            "@net_bytebuddy",
+            "@com_google_guava_guava",
+            "@net_bytebuddy_byte_buddy",
             "@com_squareup_okhttp3_okhttp",
-            "@com_squareup_okio",
-            "@org_apache_commons_exec",
-            "@org_seleniumhq_selenium_api",
+            "@com_squareup_okio_okio",
+            "@org_apache_commons_commons_exec",
+            "@org_seleniumhq_selenium_selenium_api",
         ],
     )
+
+# Artifacts for rules_jvm_external. See:
+# https://github.com/bazelbuild/rules_jvm_external#exporting-and-consuming-artifacts-from-external-repositories
+RULES_WEBTESTING_ARTIFACTS = [
+    "org.seleniumhq.selenium:selenium-api:3.141.59",
+    "org.seleniumhq.selenium:selenium-remote-driver:3.141.59",
+    "com.google.guava:guava:22.0-jre",
+]
+

--- a/web/py_repositories.bzl
+++ b/web/py_repositories.bzl
@@ -29,7 +29,7 @@ def py_repositories(**kwargs):
     "omit_" + name parameter. This is useful for users who want to be rigorous
     about declaring their own direct dependencies, or when another Bazel project
     is depended upon (e.g. rules_closure) that defines the same dependencies as
-    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    this one (e.g. com_google_guava_guava.) Alternatively, a whitelist model may be
     used by calling the individual functions this method references.
 
     Please note that while these dependencies are defined, they are not actually

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -29,7 +29,7 @@ def web_test_repositories(**kwargs):
     "omit_" + name parameter. This is useful for users who want to be rigorous
     about declaring their own direct dependencies, or when another Bazel project
     is depended upon (e.g. rules_closure) that defines the same dependencies as
-    this one (e.g. com_google_guava.) Alternatively, a whitelist model may be
+    this one (e.g. com_google_guava_guava.) Alternatively, a whitelist model may be
     used by calling the individual functions this method references.
 
     Please note that while these dependencies are defined, they are not actually


### PR DESCRIPTION
Updates all of the java library references to use the naming format of [rules_jvm_external](https://github.com/bazelbuild/rules_jvm_external). This means:

`com_google_guava` vs `com_google_guava_guava`

This repo seems to be using the naming style mentioned [here](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/java.bzl#L86), however it seems like `rules_jvm_external` is the [recommended way(?)](https://blog.bazel.build/2019/03/31/rules-jvm-external-maven.html) to reference java dependencies.

Another point of reference [gRPC java](https://github.com/grpc/grpc-java/blob/master/repositories.bzl#L209) uses this naming scheme.

The `java_library` deps have also been updated to reference a `//jar`, which is needed when the library is supplied by `maven_install`.