### PR TITLE
Stop testing on Windows since Bazel CI is not ready

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,12 +16,4 @@ platforms:
     - "--test_tag_filters=-noci,-sauce"
     test_targets:
     - "//..."
-  windows:
-    sauce: true
-    build_targets:
-    - "//..."
-    test_flags:
-    - "--test_tag_filters=-noci,-sauce"
-    test_targets:
-    - "//..."
-    
+


### PR DESCRIPTION
The build was stuck for some reason:
https://buildkite.com/bazel/rules-webtesting-saucelabs/builds/218#12ca057a-27eb-4fd0-96d4-ecc308cff929