### PR TITLE
Fix chromium path for Windows

### DIFF
--- a/third_party/chromium/BUILD.bazel
+++ b/third_party/chromium/BUILD.bazel
@@ -33,7 +33,7 @@ web_test_archive(
             "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
         },
         "//common/conditions:windows": {
-            "CHROMIUM": "chrome-win32/chrome.exe",
+            "CHROMIUM": "chrome-win/chrome.exe",
         },
     }),
     visibility = ["//browsers:__subpackages__"],


### PR DESCRIPTION
1. Declare extracted files as output so that they appear in runfiles
manifest

2. Fix the chromium path for Windows