### PR TITLE
web test not launching on windows if shell toolchain path contains whitespace

### DIFF
--- a/web/internal/windows_utils.bzl
+++ b/web/internal/windows_utils.bzl
@@ -97,7 +97,7 @@ set RUNFILES_MANIFEST_ONLY=1
 call :rlocation "{sh_script}" run_script
 for %%a in ("{bash_bin}") do set "bash_bin_dir=%%~dpa"
 set PATH=%bash_bin_dir%;%PATH%
-{bash_bin} -c "!run_script! %*"
+"{bash_bin}" -c "!run_script! %*"
 """.format(
             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
             sh_script = _file_to_manifest_path(ctx, shell_script),


### PR DESCRIPTION
The windows launcher code does currently break if the path to the bash binary contains
a whitespace. This is common on windows where programs are stored under `C:\Program Files`.

e.g.

```
:run
C:/Program Files/msys2/usr/bin/bash.exe -c "!run_script!"
```

The path needs to be quoted so that it won't be incorrectly picked up as two separate commands. Resulting in an
exception like:

```
'C:/Program' is not recognized as an internal or external command,
operable program or batch file.
```