### PR TITLE
Allow removal of dash-dash args in custom_browser

### DIFF
--- a/go/metadata/capabilities/capabilities.go
+++ b/go/metadata/capabilities/capabilities.go
@@ -723,13 +723,19 @@ func mergeLists(m1, m2 []interface{}) []interface{} {
 func mergeArgs(m1, m2 []interface{}) []interface{} {
 	m2Opts := map[string]bool{}
 
+	m2Copy := make([]interface{}, 0, len(m2))
 	for _, a := range m2 {
 		if arg, ok := a.(string); ok {
+			if strings.HasPrefix(arg, "REMOVE:--") {
+				m2Opts[arg[7:]] = true
+				continue // And leave arg out of m2Copy
+			}
 			if strings.HasPrefix(arg, "--") {
 				tokens := strings.Split(arg, "=")
 				m2Opts[tokens[0]] = true
 			}
 		}
+		m2Copy = append(m2Copy, a)
 	}
 
 	nl := []interface{}{}
@@ -747,7 +753,7 @@ func mergeArgs(m1, m2 []interface{}) []interface{} {
 		nl = append(nl, a)
 	}
 
-	nl = append(nl, m2...)
+	nl = append(nl, m2Copy...)
 	return nl
 }
 

--- a/go/metadata/capabilities/capabilities_test.go
+++ b/go/metadata/capabilities/capabilities_test.go
@@ -491,6 +491,47 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
+			name: "args -- removals",
+			input1: map[string]interface{}{
+				"args": []interface{}{
+					"an option",
+					"--anOption",
+					"--anOption=true",
+					"--optionToLeave=this",
+					map[string]interface{}{
+						"some": "map",
+					},
+				},
+			},
+			input2: map[string]interface{}{
+				"args": []interface{}{
+					"an option",
+					"REMOVE:--anOption",
+					"REMOVE:--noSuchOption",
+					"REMOVE:an option",
+					"-optionToLeave=that",
+					map[string]interface{}{
+						"some": "map",
+					},
+				},
+			},
+			result: map[string]interface{}{
+				"args": []interface{}{
+					"an option",
+					"--optionToLeave=this",
+					map[string]interface{}{
+						"some": "map",
+					},
+					"an option",
+					"REMOVE:an option",
+					"-optionToLeave=that",
+					map[string]interface{}{
+						"some": "map",
+					},
+				},
+			},
+		},
+		{
 			name: "chromeOptions to goog:chromeOptions",
 			input1: map[string]interface{}{
 				"chromeOptions": []interface{}{


### PR DESCRIPTION
An arg of name `--foo` may be removed by specifying an arg of
`REMOVE:--foo` in the custom_browser json capabilities.