### PR TITLE
Add Google mirror URL for bazel-skylib

### DIFF
--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -69,6 +69,7 @@ def bazel_skylib():
         name = "bazel_skylib",
         sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
         urls = [
+            "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
         ],
     )


### PR DESCRIPTION
Add a storage.googleapis.com/bazel-mirror URL for bazel-skylib,
so as not to hammer github (and get rate-limited).