### PR TITLE
custom_browser: put custom metadata in first place

### DIFF
--- a/web/internal/custom_browser.bzl
+++ b/web/internal/custom_browser.bzl
@@ -29,7 +29,7 @@ def _custom_browser_impl(ctx):
     ] + [ctx.attr.browser[WebTestInfo].metadata]
 
     if ctx.files.metadata:
-        metadata_files.append(ctx.file.metadata)
+        metadata_files.insert(0, ctx.file.metadata)
 
     patch = ctx.actions.declare_file("%s.tmp.json" % ctx.label.name)
     metadata.create_file(ctx = ctx, output = patch, browser_label = ctx.label)


### PR DESCRIPTION
PR #394 allowed the removal of --flags when merging metadata args, but
only when the removing args are in the later (higher-precedence)
position. `metadata.merge_files` expects higher precedence files
earlier (and reverses them before calling the actual merger program).

This change prepends the user-supplied metadata json (if supplied) to
the list of files to merge.