### PR TITLE
Feature: Kotlin Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ maven_install(
 )
 ```
 
+### Kotlin
+
+Follow the directions at [`bazelbuild/rules_kotlin`](https://github.com/bazelbuild/rules_kotlin) to setup the Kotlin toolchain. At the time of this writing, that is:
+
+```bzl
+# add the `bazelbuild/rules_kotlin` repo to your WORKSPACE, and then...
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+kotlin_repositories()
+kt_register_toolchains()
+```
+
 ### Scala
 
 ```bzl
@@ -166,6 +178,44 @@ public class BrowserTest {
    }
 
   // your tests here
+}
+```
+
+### Example Kotlin Test
+
+```kotlin
+package javatests.kotlinsample
+
+import com.google.testing.web.WebTest
+import org.openqa.selenium.WebDriver
+
+import org.junit.Test as test
+import org.junit.After as after
+import org.junit.Before as before
+
+
+class SomeTest {
+  private var driver: WebDriver? = null
+
+  @before
+  fun createDriver() {
+    driver = WebTest().newWebDriverSession()
+  }
+
+  @after
+  fun quitDriver() {
+    try {
+      driver!!.quit()
+    } finally {
+      driver = null
+    }
+  }
+
+  @test
+  fun testWebDriverFromKotlin() {
+    val wt = WebTest()
+    driver?.get(wt.HTTPAddress().resolve("/healthz").toString())
+  }
 }
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,3 +92,17 @@ scala_repositories()
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 
 scala_register_toolchains()
+
+rules_kotlin_version = "4512a83053489326a3643ef9d84e3e15420eb58e"
+rules_kotlin_sha = "5108e1fa0ac9012a92e7a5825562284fa756f469b80020d0cd7fa03c44f6bb20"
+http_archive(
+    name = "io_bazel_rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
+    type = "zip",
+    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
+    sha256 = rules_kotlin_sha,
+)
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+kotlin_repositories()
+kt_register_toolchains()

--- a/javatests/com/google/testing/web/BUILD.bazel
+++ b/javatests/com/google/testing/web/BUILD.bazel
@@ -15,6 +15,7 @@
 ################################################################################
 #
 load("//web:java.bzl", "java_web_test_suite")
+load("//web:kotlin.bzl", "kotlin_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -32,4 +33,21 @@ java_web_test_suite(
         "@junit_junit",
         "@org_seleniumhq_selenium_selenium_api",
     ],
+)
+
+kotlin_web_test_suite(
+    name = "WebKotlinTest",
+    srcs = ["WebKotlinTest.kt"],
+    test_class = "com.google.testing.web.WebKotlinTest",
+    browsers = [
+        "//browsers:chromium-local",
+        "//browsers:firefox-local",
+        "//browsers/sauce:chrome-win10",
+        "//browsers/sauce:chrome-win10-connect",
+    ],
+    deps = [
+        "//java/com/google/testing/web",
+        "@junit_junit",
+        "@org_seleniumhq_selenium_selenium_api",
+    ]
 )

--- a/javatests/com/google/testing/web/WebKotlinTest.kt
+++ b/javatests/com/google/testing/web/WebKotlinTest.kt
@@ -1,0 +1,19 @@
+package com.google.testing.web
+
+import com.google.testing.web.WebTest
+import org.openqa.selenium.WebDriver
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test as test
+
+
+@RunWith(JUnit4::class)
+class WebKotlinTest {
+  @test
+  fun testWebDriverFromKotlin() {
+    val wt = WebTest()
+    val driver = wt.newWebDriverSession()
+    driver.get(wt.HTTPAddress().resolve("/healthz").toString())
+  }
+}

--- a/web/kotlin.bzl
+++ b/web/kotlin.bzl
@@ -1,0 +1,34 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Web Test rules for Java."""
+
+load("//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
+load("//web/internal:wrap_web_test_suite.bzl", "wrap_web_test_suite")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+def kotlin_web_test_suite(name, kotlin_test_tags = DEFAULT_WRAPPED_TEST_TAGS, **kwargs):
+    """Defines a test_suite of web_test targets that wrap a java_test target.
+
+    Args:
+        name: The base name of the test.
+        kotlin_test_tags: A list of test tag strings to use for the scala_test
+          target.
+        **kwargs: Arguments for wrapped_web_test_suite
+    """
+    wrap_web_test_suite(
+        name = name,
+        rule = kt_jvm_test,
+        wrapped_test_tags = kotlin_test_tags,
+        **kwargs
+    )


### PR DESCRIPTION
This changeset adds support for running tests written in Kotlin, via the same mechanism used to run Scala tests. The README is also updated with a test sample, and there is a unit test alongside `WebTestTest.java`, but written in Kotlin.