### PR TITLE
Fix4ChromiumToWork

### DIFF
--- a/browsers/chromium-local.json
+++ b/browsers/chromium-local.json
@@ -6,6 +6,7 @@
       "binary" : "%FILE:CHROMIUM%",
       "args" : [
         "--headless", 
+        "--no-sandbox",
         "--use-gl=swiftshader-webgl"
       ]
     },


### PR DESCRIPTION
change will fix issue in
```
2020/07/28 08:44:51.634619 Listening on :33196
JUnit4 Test Runner
.Starting ChromeDriver 76.0.3809.0 (9fcb9ac87427f9327c726808c64f2e8a0c719b1a-refs/heads/master@{#664981}) on port 37172
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
[1595925892.449][SEVERE]: bind() failed: Cannot assign requested address (99)
2020/07/28 08:44:55.691930 Error shutting down driver: os: process already finished
2020/07/28 08:44:55.692073 Error creating webdriver session: [Go WebDriver Client] (unknown error) unknown error: Chrome failed to start: exited abnormally
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /home/fyre/.cache/bazel/_bazel_fyre/30bbde0508de9b9df093acd21ee0ffba/sandbox/processwrapper-sandbox/1168/execroot/com_systemlogic_monorepo/bazel-out/k8-fastbuild/bin/javatests/com/google/testing/web/WebTestTest_chromium-local.sh.runfiles/io_bazel_rules_webtesting/third_party/chromium/chromium.out/chrome-linux/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
Starting ChromeDriver 76.0.3809.0 (9fcb9ac87427f9327c726808c64f2e8a0c719b1a-refs/heads/master@{#664981}) on port 41451
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
[1595925895.699][SEVERE]: bind() failed: Cannot assign requested address (99)
2020/07/28 08:44:58.936667 Error shutting down driver: os: process already finished
2020/07/28 08:44:58.936849 Error creating webdriver session: [Go WebDriver Client] (unknown error) unknown error: Chrome failed to start: exited abnormally
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /home/fyre/.cache/bazel/_bazel_fyre/30bbde0508de9b9df093acd21ee0ffba/sandbox/processwrapper-sandbox/1168/execroot/com_systemlogic_monorepo/bazel-out/k8-fastbuild/bin/javatests/com/google/testing/web/WebTestTest_chromium-local.sh.runfiles/io_bazel_rules_webtesting/third_party/chromium/chromium.out/chrome-linux/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
Starting ChromeDriver 76.0.3809.0 (9fcb9ac87427f9327c726808c64f2e8a0c719b1a-refs/heads/master@{#664981}) on port 45314
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
[1595925898.943][SEVERE]: bind() failed: Cannot assign requested address (99)
2020/07/28 08:45:02.187499 Error shutting down driver: os: process already finished
2020/07/28 08:45:02.187655 Error creating webdriver session: [Go WebDriver Client] (unknown error) unknown error: Chrome failed to start: exited abnormally
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /home/fyre/.cache/bazel/_bazel_fyre/30bbde0508de9b9df093acd21ee0ffba/sandbox/processwrapper-sandbox/1168/execroot/com_systemlogic_monorepo/bazel-out/k8-fastbuild/bin/javatests/com/google/testing/web/WebTestTest_chromium-local.sh.runfiles/io_bazel_rules_webtesting/third_party/chromium/chromium.out/chrome-linux/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
E
Time: 10.29
There was 1 failure:
1) newWebDriverSession(com.google.testing.web.WebTestTest)
org.openqa.selenium.SessionNotCreatedException: [Go WebDriver Client] (session not created) unable to create session: [Go WebDriver Client] (unknown error) unknown error: Chrome failed to start: exited abnormally
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /home/fyre/.cache/bazel/_bazel_fyre/30bbde0508de9b9df093acd21ee0ffba/sandbox/processwrapper-sandbox/1168/execroot/com_systemlogic_monorepo/bazel-out/k8-fastbuild/bin/javatests/com/google/testing/web/WebTestTest_chromium-local.sh.runfiles/io_bazel_rules_webtesting/third_party/chromium/chromium.out/chrome-linux/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.) (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 9.83 seconds
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'papaw1.systemlogic.com', ip: '172.16.175.224', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-1062.21.1.el7.x86_64', java.version: '1.8.0_252'
Driver info: driver.version: RemoteWebDriver
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.openqa.selenium.remote.ErrorHandler.createThrowable(ErrorHandler.java:214)
        at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:166)
        at org.openqa.selenium.remote.JsonWireProtocolResponse.lambda$errorHandler$0(JsonWireProtocolResponse.java:54)
        at org.openqa.selenium.remote.HandshakeResponse.lambda$getResponseFunction$0(HandshakeResponse.java:30)
        at org.openqa.selenium.remote.ProtocolHandshake.lambda$createSession$0(ProtocolHandshake.java:126)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)
        at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531)
        at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:128)
        at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:74)
        at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:136)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
        at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:213)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:131)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:144)
        at com.google.testing.web.WebTest.newWebDriverSession(WebTest.java:96)
        at com.google.testing.web.WebTest.newWebDriverSession(WebTest.java:87)
        at com.google.testing.web.WebTestTest.newWebDriverSession(WebTestTest.java:29)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:112)
        at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:153)
        at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:84)

FAILURES!!!
Tests run: 1,  Failures: 1