### PR TITLE
build: improve release script to create tarball directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bazel-*
 user.bazelrc
 
 .idea/
+dist/

--- a/tools/copy.bara.sky
+++ b/tools/copy.bara.sky
@@ -47,7 +47,7 @@ core.workflow(
             "bazel-bin/go/wsl/main/main_*",
             "bazel-bin/go/wtl/main/main_*",
         ],
-        exclude = ["go/metadata/main/**", "**/*.runfiles_manifest"],
+        exclude = [".bazelrc", "go/metadata/main/**", "**/*.runfiles_manifest"],
     ),
     transformations = [
         core.move("bazel-bin/go/metadata/main", "go/metadata/main"),


### PR DESCRIPTION
Improves the release script to create the tarball directly. This
makes it easier to cut new releases as a few manual steps are
now automated. This change also includes some fallback logic
for finding Copybara for Googlers (like it was done previously),
and no longer relies on a release directory to be specified as `$1`
argument to the Bash script.

This should partially help with #428 