### PR TITLE
Update upload_file endpoint in hub.go

### DIFF
--- a/go/wsl/hub/hub.go
+++ b/go/wsl/hub/hub.go
@@ -82,7 +82,7 @@ func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(path) == 3 && path[2] == "file" {
+	if (len(path) == 3 && path[2] == "file") || (len(path) == 4 && path[2] == "se" && path[3] == "file") {
 		h.uploader.ServeHTTP(w, r)
 		return
 	}


### PR DESCRIPTION
Update upload_file endpoint to support both "session/session_id/file" and "session/session_id/se/file" to be compatible for selenium new change(https://github.com/SeleniumHQ/selenium/commit/824617b75181f0cb8a83025d8acfb70b37038f6b) and provide backward compatibility.