### PR TITLE
Remove sauce integration.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,11 +1,10 @@
 ---
 platforms:
   ubuntu1804:
-    sauce: true
     build_targets:
     - "//..."
     test_flags:
-    - "--test_tag_filters=-noci,-external,-native"
+    - "--test_tag_filters=-noci,-external,-native,-sauce"
     - "--test_output=streamed"
     test_targets:
     - "//..."


### PR DESCRIPTION
The integration was removed from Bazel CI https://github.com/bazelbuild/continuous-integration/commit/d7304dc1144409d7391e66f014f1ebb23452cae2

The removal is causing master builds to fail:
https://buildkite.com/bazel/rules-webtesting-saucelabs/builds/1185