### PR TITLE
fix: batch rlocation fails to find manifest when --enable_runfiles is set

### DIFF
--- a/web/internal/windows_utils.bzl
+++ b/web/internal/windows_utils.bzl
@@ -35,6 +35,9 @@ if "%RUNFILES_MANIFEST_ONLY%" neq "1" (
   set %~2=%~1
   exit /b 0
 )
+if exist "%RUNFILES_DIR%" (
+  set RUNFILES_MANIFEST_FILE=%RUNFILES_DIR%_manifest
+)
 if "%RUNFILES_MANIFEST_FILE%" equ "" (
   set RUNFILES_MANIFEST_FILE=%~f0.runfiles\MANIFEST
 )


### PR DESCRIPTION
This fix was added to `rules_nodejs`'s copy in https://github.com/bazelbuild/rules_nodejs/commit/3ffefa1ea3b4024644ffbbc5e59a34fdc12aefd9