### PR TITLE
Remove empty glob

### DIFF
--- a/web/internal/BUILD.bazel
+++ b/web/internal/BUILD.bazel
@@ -25,7 +25,6 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(
     glob([
-        "*.bat",
         "*.sh",
         "*.sh.template",
     ]),


### PR DESCRIPTION
There is no bat file and this pattern is not globbing anything.
This prevents to build with the incompatible_disallow_empty_glob.
See: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1320#018435e1-7542-4a30-879a-38248876b72e