### PR TITLE
Add Selenium Support package to java_repositories()

### DIFF
--- a/web/java_repositories.bzl
+++ b/web/java_repositories.bzl
@@ -68,6 +68,8 @@ def java_repositories(**kwargs):
         org_seleniumhq_selenium_selenium_api()
     if should_create_repository("org_seleniumhq_selenium_selenium_remote_driver", kwargs):
         org_seleniumhq_selenium_selenium_remote_driver()
+    if should_create_repository("org_seleniumhq_selenium_selenium_support", kwargs):
+        org_seleniumhq_selenium_selenium_support()
     if kwargs.keys():
         print("The following parameters are unknown: " + str(kwargs.keys()))
 
@@ -225,6 +227,26 @@ def org_seleniumhq_selenium_selenium_remote_driver():
             "@com_squareup_okio_okio",
             "@org_apache_commons_commons_exec",
             "@org_seleniumhq_selenium_selenium_api",
+        ],
+    )
+
+def org_seleniumhq_selenium_selenium_support():
+    java_import_external(
+        name = "org_seleniumhq_selenium_selenium_support",
+        jar_sha256 = "2c74196d15277ce6003454d72fc3434091dbf3ba65060942719ba551509404d8",
+        jar_urls = [
+            "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.141.59/selenium-support-3.141.59.jar",
+        ],
+        licenses = ["notice"],  # The Apache Software License, Version 2.0
+        testonly_ = 1,
+        deps = [
+            "@com_google_guava_guava",
+            "@net_bytebuddy_byte_buddy",
+            "@com_squareup_okhttp3_okhttp",
+            "@com_squareup_okio_okio",
+            "@org_apache_commons_commons_exec",
+            "@org_seleniumhq_selenium_selenium_api",
+            "@org_seleniumhq_selenium_selenium_remote_driver",
         ],
     )
 


### PR DESCRIPTION
This package is needed when a user wants to use the [Java WebTest API](https://github.com/bazelbuild/rules_webtesting/blob/master/java/com/google/testing/web/WebTest.java) with Selenium [Wait](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/ui/Wait.html) to interact with G_testrunner. 

Usage example:
```
import com.google.testing.web.WebTest;
import org.openqa.selenium.JavascriptExecutor;
import org.openqa.selenium.WebDriver;
import org.openqa.selenium.support.ui.FluentWait;

public class TestDriver {
  private WebDriver driver;
  private String testURL;

  public WebtestDriver(String testURL) {
    this.driver = new WebTest().newWebDriverSession();
    this.testURL = testURL;
  }

  public void run() {
    driver.get(this.testURL);

    new FluentWait<>((JavascriptExecutor) driver)
        .pollingEvery(Duration.ofMillis(POLL_INTERVAL))
        .withTimeout(Duration.ofSeconds(TEST_TIMEOUT))
        .until(executor ->
                (boolean) executor.executeScript("return window.top.G_testRunner.isFinished()")));
  }
}
```