### PR TITLE
fix: improve error message when missing tags[browser]

### DIFF
--- a/web/web.bzl
+++ b/web/web.bzl
@@ -110,8 +110,11 @@ def _get_kwargs(browser, in_kwargs):
                 out_kwargs[k] = v["default"]
         else:
             out_kwargs[k] = v
-
-    if not out_kwargs["tags"]:
+    if "tags" not in out_kwargs:
+        fail("expeted \"default\" or \"{browser}\" dict key in tags argument.".format(
+            browser = browser,
+        ))
+    elif not out_kwargs["tags"]:
         out_kwargs["tags"] = ["browser:" + browser]
     else:
         out_kwargs["tags"] = ["browser:" + browser] + out_kwargs["tags"]


### PR DESCRIPTION
Handle error when invalid `tags` provided in `py_web_test_suite` and `go_web_test_suite`.
If `tags[browser_name]` is missing, below erorr will be raised. 
```python
        File ".../.cache/bazel/53d5c478a9b654e0091a6804f2465ac0/external/io_bazel_rules_webtesting/web/web.bzl", line 114, column 22, in _get_kwargs
                if not out_kwargs["tags"]:
Error: key "tags" not found in dictionary
```

After apply this PR,  error message improved.
```python
Error in fail: expeted "default" or "chromium-local" dict key in tags argument.
```

------ 
Example patch to reproduce error. (`git apply` to apply)
After apply this patch, run `bazel build //testing/web:webtest_test_chromium-local` to reproduce error.
```
diff --git a/testing/web/BUILD.bazel b/testing/web/BUILD.bazel
index 8d53025..2bea226 100644
--- a/testing/web/BUILD.bazel
+++ b/testing/web/BUILD.bazel
@@ -39,9 +39,6 @@ py_web_test_suite(
         "//browsers/sauce:chrome-win10-connect",
     ],
     tags = {
-        "chromium-local": [
-            "native",
-        ],
         "chrome-win10": [
             "exclusive",
             "sauce",
```