### PR TITLE
buffer signals in wtl

### DIFF
--- a/go/wtl/wtl.go
+++ b/go/wtl/wtl.go
@@ -75,7 +75,7 @@ func RegisterEnvProviderFunc(name string, p envProvider) {
 func Run(d diagnostics.Diagnostics, testPath, mdPath string, httpPort, httpsPort, debuggerPort int) int {
 	ctx := context.Background()
 
-	testTerminated := make(chan os.Signal)
+	testTerminated := make(chan os.Signal, 1)
 	signal.Notify(testTerminated, syscall.SIGTERM, syscall.SIGINT)
 
 	proxyStarted := make(chan error)


### PR DESCRIPTION
The docs for signal.Notify say that signals will be dropped unless the channel is buffered. This was noticed with a rules_go nogo run of `@org_golang_x_tools//go/analysis/passes/sigchanyzer`.