### PR TITLE
Build with incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,3 +13,6 @@ test --local_test_jobs=5
 # the sandbox strategy is used anyway and runfile forests are not needed.
 # Related Bazel bug: https://github.com/bazelbuild/bazel/issues/4327.
 build --nobuild_runfile_links
+
+# Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
+build --incompatible_disallow_empty_glob


### PR DESCRIPTION
In order to flip the flag, all downstream projects should be adapted. However, it is hard to fix them all if there are constant regressions. Adding it to the CI will ensure that once the project can build with incompatible_disallow_empty_glob it can keep building like that.

See: bazelbuild/bazel#15327