### PR TITLE
Remove browser_overrides

### DIFF
--- a/web/internal/wrap_web_test_suite.bzl
+++ b/web/internal/wrap_web_test_suite.bzl
@@ -81,7 +81,6 @@ def wrap_web_test_suite(
         name = name,
         args = args,
         browsers = browsers,
-        browser_overrides = browser_overrides,
         config = config,
         data = web_test_data,
         flaky = flaky,


### PR DESCRIPTION
The browser_overrides is passed (with None value) to `web_test` rule, that doesn't define such an attribute.

Example failure: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1645#018a8918-aeef-43fa-b0d6-f04d3204ef86
Addresses: https://github.com/bazelbuild/bazel/issues/19403