### PR TITLE
Replace instances of to_json() method with json.encode(..)

### DIFF
--- a/web/internal/metadata.bzl
+++ b/web/internal/metadata.bzl
@@ -87,7 +87,7 @@ def _create_file(
 
     ctx.actions.write(
         output = output,
-        content = struct(**fields).to_json(),
+        content = json.encode(struct(**fields)),
         is_executable = False,
     )
 


### PR DESCRIPTION
The to_json and to_proto methods on struct are deprecated and will be
removed. The "json" and "proto" builtin modules should be used instead.

This replaces instances of `foo.to_json()` with `json.encode(foo)`.