### PR TITLE
Update web/versioned/browsers-0.3.4.bzl 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,7 +77,7 @@ scala_deps.toolchains(
 
 ##### Browsers dependencies #####
 browser_repositories = use_extension("//web:extension.bzl", "browser_repositories_extension")
-browser_repositories.install(version = "0.3.3")
+browser_repositories.install(version = "0.3.4")
 use_repo(
     browser_repositories,
     "com_saucelabs_sauce_connect_linux_x64",

--- a/web/versioned/browsers-0.3.4.bzl
+++ b/web/versioned/browsers-0.3.4.bzl
@@ -200,6 +200,9 @@ def org_mozilla_firefox():
     )
 
     platform_archive(
+        # Firefox has a launcher that conditionally starts x64/arm64. This means that the
+        # x64 and arm64 repositories download the same binaries. We preserve separate
+        # repositories to allow for dedicated ARM/x64 binaries if needed in the future.
         name = "org_mozilla_firefox_macos_arm64",
         licenses = ["reciprocal"],  # MPL 2.0
         sha256 = "c06c4e58179acaf55d05c3be41d0d4cdd68f811a75322a39557d91121aa2ef74",

--- a/web/versioned/browsers-0.3.4.bzl
+++ b/web/versioned/browsers-0.3.4.bzl
@@ -186,7 +186,21 @@ def org_mozilla_firefox():
     )
 
     platform_archive(
-        name = "org_mozilla_firefox_macos",
+        name = "org_mozilla_firefox_macos_x64",
+        licenses = ["reciprocal"],  # MPL 2.0
+        sha256 = "c06c4e58179acaf55d05c3be41d0d4cdd68f811a75322a39557d91121aa2ef74",
+        # Firefox v97.0
+        urls = [
+            "https://ftp.mozilla.org/pub/firefox/releases/97.0/mac/en-US/Firefox%2097.0.dmg",
+            "https://storage.googleapis.com/dev-infra-mirror/firefox/97.0/mac_x64/browser-bin.dmg",
+        ],
+        named_files = {
+            "FIREFOX": "Firefox.app/Contents/MacOS/firefox",
+        },
+    )
+
+    platform_archive(
+        name = "org_mozilla_firefox_macos_arm64",
         licenses = ["reciprocal"],  # MPL 2.0
         sha256 = "c06c4e58179acaf55d05c3be41d0d4cdd68f811a75322a39557d91121aa2ef74",
         # Firefox v97.0


### PR DESCRIPTION
This is to fix error "module extension "browser_repositories_extension" from "@@rules_webtesting~//web:extension.bzl" does not generate repository "org_mozilla_firefox_macos_arm64", yet it is imported as "org_mozilla_firefox_macos_arm64" in the usage at @@rules_webtesting~//:MODULE.bazel:79:37"
